### PR TITLE
Fix missing global errors (no Audio module yet)

### DIFF
--- a/src/project.godot
+++ b/src/project.godot
@@ -37,7 +37,6 @@ config/icon="res://icon.svg"
 EventBus="*res://global/event_bus.gd"
 FmodManager="*res://addons/fmod/FmodManager.gd"
 Logger="*res://addons/godot-logger/logger.gd"
-Audio="*res://modules/audio/audio.gd"
 
 [debug_draw_3d]
 


### PR DESCRIPTION
Fix for these errors appearing on loading the game project:

<img width="1261" height="353" alt="image" src="https://github.com/user-attachments/assets/3a3fbb6e-8fef-4ff0-a4af-15a5005b98af" />
