### PR TITLE
Prevent auto-modification of files on pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,5 +5,5 @@ repos:
     hooks:
       - id: gdlint
       - id: gdformat
-        args: [--check]
+        args: [--check, --diff]
 exclude: ^src/addons


### PR DESCRIPTION
When I tried to commit, I got this output:

```
ggdlint...................................................................it Passed
gdformat.................................................................Failed
- hook id: gdformat
- files were modified by this hook

reformatted src/main.gd
1 file reformatted, 0 files left unchanged.
```

So it actually reformatted my code automatically, which I think isn't ideal. I think we should just alert the user, and have them fix it if they want by running gdformat manually.

Unless we trust gdformat 100% but also the workflow is a bit weird because then after the files get reformatted, you just run the commit again and everything magically works the 2nd time (because the files were auto-modified).

This PR makes it manual and does a non-destructive check only, which I think is better.

Thoughts?