### PR TITLE
Add builds/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Exported Game Builds
+builds/
+
 # Temp files
 ~*
 


### PR DESCRIPTION
Allows us to export builds locally without dealing with git