### PR TITLE
Add gdextensions to export preset of web builds

### DIFF
--- a/src/export_presets.cfg
+++ b/src/export_presets.cfg
@@ -22,7 +22,7 @@ script_export_mode=2
 
 custom_template/debug=""
 custom_template/release=""
-variant/extensions_support=false
+variant/extensions_support=true
 variant/thread_support=false
 vram_texture_compression/for_desktop=true
 vram_texture_compression/for_mobile=false

--- a/src/export_presets.cfg
+++ b/src/export_presets.cfg
@@ -3,22 +3,27 @@
 name="web_release"
 platform="Web"
 runnable=true
+advanced_options=true
 dedicated_server=false
 custom_features=""
 export_filter="all_resources"
 include_filter=""
 exclude_filter=""
 export_path="builds/web/web_release/index.html"
+patches=PackedStringArray()
 encryption_include_filters=""
 encryption_exclude_filters=""
+seed=0
 encrypt_pck=false
 encrypt_directory=false
+script_export_mode=2
 
 [preset.0.options]
 
 custom_template/debug=""
 custom_template/release=""
 variant/extensions_support=false
+variant/thread_support=false
 vram_texture_compression/for_desktop=true
 vram_texture_compression/for_mobile=false
 html/export_icon=true
@@ -28,6 +33,7 @@ html/canvas_resize_policy=2
 html/focus_canvas_on_start=true
 html/experimental_virtual_keyboard=false
 progressive_web_app/enabled=false
+progressive_web_app/ensure_cross_origin_isolation_headers=true
 progressive_web_app/offline_page=""
 progressive_web_app/display=1
 progressive_web_app/orientation=0
@@ -39,18 +45,22 @@ progressive_web_app/background_color=Color(0, 0, 0, 1)
 [preset.1]
 
 name="linux_release"
-platform="Linux/X11"
+platform="Linux"
 runnable=true
+advanced_options=true
 dedicated_server=false
 custom_features=""
 export_filter="all_resources"
 include_filter=""
 exclude_filter=""
 export_path="builds/linux/linux_release.x86_64"
+patches=PackedStringArray()
 encryption_include_filters=""
 encryption_exclude_filters=""
+seed=0
 encrypt_pck=false
 encrypt_directory=false
+script_export_mode=2
 
 [preset.1.options]
 
@@ -58,10 +68,8 @@ custom_template/debug=""
 custom_template/release=""
 debug/export_console_wrapper=1
 binary_format/embed_pck=false
-texture_format/bptc=true
-texture_format/s3tc=true
-texture_format/etc=false
-texture_format/etc2=false
+texture_format/s3tc_bptc=true
+texture_format/etc2_astc=false
 binary_format/architecture="x86_64"
 ssh_remote_deploy/enabled=false
 ssh_remote_deploy/host="user@host_ip"
@@ -75,22 +83,30 @@ unzip -o -q \"{temp_dir}/{archive_name}\" -d \"{temp_dir}\"
 ssh_remote_deploy/cleanup_script="#!/usr/bin/env bash
 kill $(pgrep -x -f \"{temp_dir}/{exe_name} {cmd_args}\")
 rm -rf \"{temp_dir}\""
+texture_format/bptc=true
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false
 
 [preset.2]
 
 name="windows"
 platform="Windows Desktop"
 runnable=true
+advanced_options=true
 dedicated_server=false
 custom_features=""
 export_filter="all_resources"
 include_filter=""
 exclude_filter=""
 export_path="builds/windows/windows_release.x86_64.exe"
+patches=PackedStringArray()
 encryption_include_filters=""
 encryption_exclude_filters=""
+seed=0
 encrypt_pck=false
 encrypt_directory=false
+script_export_mode=2
 
 [preset.2.options]
 
@@ -98,10 +114,8 @@ custom_template/debug=""
 custom_template/release=""
 debug/export_console_wrapper=1
 binary_format/embed_pck=false
-texture_format/bptc=true
-texture_format/s3tc=true
-texture_format/etc=false
-texture_format/etc2=false
+texture_format/s3tc_bptc=true
+texture_format/etc2_astc=false
 binary_format/architecture="x86_64"
 codesign/enable=false
 codesign/timestamp=true
@@ -121,6 +135,8 @@ application/file_description=""
 application/copyright=""
 application/trademarks=""
 application/export_angle=0
+application/export_d3d12=0
+application/d3d12_agility_sdk_multiarch=true
 ssh_remote_deploy/enabled=false
 ssh_remote_deploy/host="user@host_ip"
 ssh_remote_deploy/port="22"
@@ -138,3 +154,7 @@ Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorActi
 ssh_remote_deploy/cleanup_script="Stop-ScheduledTask -TaskName godot_remote_debug -ErrorAction:SilentlyContinue
 Unregister-ScheduledTask -TaskName godot_remote_debug -Confirm:$false -ErrorAction:SilentlyContinue
 Remove-Item -Recurse -Force '{temp_dir}'"
+texture_format/bptc=true
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false


### PR DESCRIPTION
There's a separate commit that updates the presets based on whatever the default is (for me, I guess?). I'm not sure if maybe a different version of godot was used, or if the starting presets have some fields missing, but yeah

The main commit updates export gdextensions for web builds. this won't let us use fmod but as we haven't decided yet whether to keep it or not,  it won't break anything