### PR TITLE
Update README with channel for requesting GitHub repo access

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If your Google account ID/email doesn't match your discord username, then please
 
 ### GitHub Repo Access - For Coders
 
-To gain access to GitHub, request access in the `#up-the-chain` channel on discord.
+To gain access to GitHub, request access in the `#devops` channel on discord.
 
 ### Git LFS - For Coders
 


### PR DESCRIPTION
The #up-the-chain channel is archived, so replaced it with #devops in the README.