### PR TITLE
Update LICENSE file to point out dual licensing

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,9 @@
+This project is dual-licensed:
+- `CC BY-NC-SA 4.0` for all assets
+- `MIT License` for everything else
+
+-----------------------------------------------------------------------------
+
 MIT License
 
 Copyright (c) 2025 100 Devs - 1 Game


### PR DESCRIPTION
A lot of people might not see the licensing line in the README so I think it's a good idea to denote the dual-licensing in the main/root LICENSE file as well. It's probably where most people will check, and it's potentially misleading if that simply says it's MIT and people assume that applies to the whole project.