### PR TITLE
Lock specific project.godot settings

### DIFF
--- a/.hooks/check_locked_project_settings.py
+++ b/.hooks/check_locked_project_settings.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+import os
+import re
+import sys
+import subprocess
+
+#!/usr/bin/env python3
+import sys
+
+# List of settings that should not appear in project.godot
+LOCKED_KEYS = [
+    "rendering_method",
+    # Add more locked keys here if needed
+]
+
+def check_locked_keys_absent(path: str) -> bool:
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            content = f.read()
+    except Exception as e:
+        print(f"Error reading {path}: {e}")
+        return False
+
+    has_violation = False
+    for key in LOCKED_KEYS:
+        if key in content:
+            print(f"[ERROR] '{path}' should NOT contain locked key '{key}'. Please remove or revert it.")
+            has_violation = True
+
+    return not has_violation
+
+def main():
+    paths = sys.argv[1:]
+    success = True
+
+    for path in paths:
+        if path.endswith("project.godot"):
+            if not check_locked_keys_absent(path):
+                success = False
+
+    return 0 if success else 1
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.hooks/check_snake_paths.py
+++ b/.hooks/check_snake_paths.py
@@ -31,7 +31,7 @@ def main():
                 invalid_dirs.add(part)
 
     if invalid_dirs:
-        print("❌ These directory or file names are NOT snake_case:")
+        print("Error: These directory or file names are NOT snake_case:")
         for d in sorted(invalid_dirs):
             print(f"  - {d}")
         return 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,5 +24,9 @@ repos:
         entry: ./.hooks/check_snake_paths.py
         language: python
         exclude: '^\.github/|src/addons/|README\.md$|LICENSE$|^.pre-commit-config.yaml$'
+      - id: check-locked-project-settings
+        name: Check that locked project settings were not modified
+        entry: ./.hooks/check_locked_project_settings.py
+        language: python
 
 exclude: '^src/addons/'

--- a/scripts/disable_gl_compatibility.py
+++ b/scripts/disable_gl_compatibility.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+PROJECT_FILE = "src/project.godot"
+
+BLOCK = [
+    "\n",
+    "[rendering]\n",
+    "\n",
+    'renderer/rendering_method="gl_compatibility"\n',
+    'renderer/rendering_method.mobile="gl_compatibility"\n',
+]
+
+with open(PROJECT_FILE, "r", encoding="utf-8", newline="\n") as f:
+    lines = f.readlines()
+
+result = []
+i = 0
+while i < len(lines):
+    # Check if block matches starting at line i
+    if lines[i:i+len(BLOCK)] == BLOCK:
+        i += len(BLOCK)  # skip the block entirely
+    else:
+        result.append(lines[i])
+        i += 1
+
+with open(PROJECT_FILE, "w", encoding="utf-8", newline="\n") as f:
+    f.writelines(result)
+
+print(f"Removed exact rendering block from {PROJECT_FILE} if present.")

--- a/scripts/enable_gl_compatibility.sh
+++ b/scripts/enable_gl_compatibility.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+PROJECT_FILE="src/project.godot"
+
+# Check if already present
+if grep -q "rendering_method" "$PROJECT_FILE"; then
+  echo "Rendering method already present in $PROJECT_FILE"
+  exit 0
+fi
+
+# Append the block to the file
+cat <<EOL >> "$PROJECT_FILE"
+
+[rendering]
+
+renderer/rendering_method="gl_compatibility"
+renderer/rendering_method.mobile="gl_compatibility"
+EOL
+
+echo "Added rendering method block to $PROJECT_FILE"


### PR DESCRIPTION
My potato laptop can't handle the forward-plus renderer (Godot 4 default) and gives me infinite rendering errors when trying to run a game. I wish it did a fallback, but for whatever reason, it doesn't. If I manually change project.godot and set the renderer to gl_compatibility then everything runs fine.

But, we probably don't want to do this for everyone. So I tried to find a way to override project.godot settings locally, but there doesn't seem to be a way to do this.

So we're stuck with me changing this setting locally for my dev environment, but there's a chance I might accidentally commit this change and although we have PR reviews, I still don't want to waste people's time on my mistakes.

So here is a pre-commit script to ensure that the renderer is locked (unless we all decide we want to change it).

I also added scripts to enable/disable gl_compatibility which I will personally use, but also might be helpful for anyone else running into this issue on the project.