### PR TITLE
Add a debug UI component for quickly executing testing code

### DIFF
--- a/src/modules/debug/debug_button.gd
+++ b/src/modules/debug/debug_button.gd
@@ -1,0 +1,6 @@
+class_name DebugButton
+
+extends Node
+
+var label: String = ""
+var method: String = ""

--- a/src/modules/debug/debug_button.gd.uid
+++ b/src/modules/debug/debug_button.gd.uid
@@ -1,0 +1,1 @@
+uid://bniv0kd24eb7w

--- a/src/modules/debug/debug_popup.gd
+++ b/src/modules/debug/debug_popup.gd
@@ -1,0 +1,42 @@
+# How to use the DebugPopup
+#
+# Step 1. Add the DebugPopup to your scene.
+# Step 2. Go to the Inspector for DebugPopup and add elements to the
+#         Debug Functions array. Each element is a string that will be used
+#         to call a debug function in the parent scene.
+# Step 3. Define a function debug_<name> where <name> is what you specified.
+# Step 4. Run your scene.
+# Step 5. Press the hotkey (default X) to load the DebugPopup.
+# Step 6. Click your debug button and ensure that it executes the function
+#         you defined in the parent scene.
+
+class_name DebugPopup
+
+extends Control
+
+# Define debug buttons by providing the names of signals that will be emitted.
+@export var debug_functions: Array[String] = []
+
+
+func _ready() -> void:
+	# By default, the debug popup is not visible.
+	visible = false
+
+	for function_name in debug_functions:
+		var new_button = Button.new()
+		new_button.text = function_name
+		new_button.connect("pressed", Callable(self, "_button_pressed").bind(function_name))
+		$ShortcutButtons.add_child(new_button)
+
+
+func _input(event: InputEvent) -> void:
+	if event.is_action_pressed("toggle_debug_popup"):
+		print("Toggling the DebugPopup")
+		visible = !visible
+
+
+func _button_pressed(function_name: String) -> void:
+	var parent = get_parent()
+	if parent != null:
+		print("Calling debug_" + function_name + "() in parent node.")
+		parent.call("debug_" + function_name)

--- a/src/modules/debug/debug_popup.gd.uid
+++ b/src/modules/debug/debug_popup.gd.uid
@@ -1,0 +1,1 @@
+uid://bu3iegvrpg3ve

--- a/src/modules/debug/debug_popup.tscn
+++ b/src/modules/debug/debug_popup.tscn
@@ -1,0 +1,50 @@
+[gd_scene load_steps=2 format=3 uid="uid://oatd3ruxn0qu"]
+
+[ext_resource type="Script" uid="uid://bu3iegvrpg3ve" path="res://modules/debug/debug_popup.gd" id="1_gwiye"]
+
+[node name="DebugPopup" type="Control"]
+custom_minimum_size = Vector2(1920, 1080)
+layout_mode = 3
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+script = ExtResource("1_gwiye")
+
+[node name="ColorRect" type="ColorRect" parent="."]
+layout_mode = 1
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0, 0, 0, 0.207843)
+
+[node name="Label" type="Label" parent="."]
+layout_mode = 1
+anchors_preset = 5
+anchor_left = 0.5
+anchor_right = 0.5
+offset_left = -180.5
+offset_right = 180.5
+offset_bottom = 50.0
+grow_horizontal = 2
+text = "Debugging Shortcuts"
+
+[node name="ShortcutButtons" type="GridContainer" parent="."]
+custom_minimum_size = Vector2(1000, 800)
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -20.0
+offset_top = -20.0
+offset_right = 20.0
+offset_bottom = 20.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/h_separation = 10
+theme_override_constants/v_separation = 10

--- a/src/modules/menu/main_menu.gd
+++ b/src/modules/menu/main_menu.gd
@@ -1,0 +1,5 @@
+extends Node2D
+
+
+func debug_hello_world() -> void:
+	print("hello: executing code in parent")

--- a/src/modules/menu/main_menu.gd.uid
+++ b/src/modules/menu/main_menu.gd.uid
@@ -1,0 +1,1 @@
+uid://br6m2cbo4864k

--- a/src/modules/menu/main_menu.tscn
+++ b/src/modules/menu/main_menu.tscn
@@ -1,7 +1,9 @@
-[gd_scene load_steps=7 format=3 uid="uid://khnsbhc4bqj8"]
+[gd_scene load_steps=9 format=3 uid="uid://khnsbhc4bqj8"]
 
 [ext_resource type="PackedScene" uid="uid://b1htr4csi273e" path="res://modules/placeholder/placeholder.tscn" id="1_sqara"]
+[ext_resource type="Script" uid="uid://br6m2cbo4864k" path="res://modules/menu/main_menu.gd" id="1_tsonj"]
 [ext_resource type="Script" uid="uid://dx8li0wjwcoe3" path="res://modules/placeholder/placeholder_button.gd" id="2_6s0ul"]
+[ext_resource type="PackedScene" uid="uid://oatd3ruxn0qu" path="res://modules/debug/debug_popup.tscn" id="3_cvkr5"]
 
 [sub_resource type="Resource" id="Resource_cvkr5"]
 script = ExtResource("2_6s0ul")
@@ -28,7 +30,18 @@ scene_path = ""
 metadata/_custom_type_script = "uid://dx8li0wjwcoe3"
 
 [node name="MainMenu" type="Node2D"]
+script = ExtResource("1_tsonj")
 
 [node name="Placeholder" parent="." instance=ExtResource("1_sqara")]
 for_text = "Main Menu Screen"
 buttons = Array[ExtResource("2_6s0ul")]([SubResource("Resource_cvkr5"), SubResource("Resource_e5aks"), SubResource("Resource_gl3cg"), SubResource("Resource_a0d1e")])
+
+[node name="DebugPopup" parent="." instance=ExtResource("3_cvkr5")]
+anchors_preset = 0
+anchor_right = 0.0
+anchor_bottom = 0.0
+offset_right = 1920.0
+offset_bottom = 1080.0
+grow_horizontal = 1
+grow_vertical = 1
+debug_functions = Array[String](["hello_world"])

--- a/src/project.godot
+++ b/src/project.godot
@@ -47,6 +47,14 @@ enabled=PackedStringArray("res://addons/format_on_save/plugin.cfg", "res://addon
 
 theme/custom="uid://sbbn1spr2jvx"
 
+[input]
+
+toggle_debug_popup={
+"deadzone": 0.2,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":88,"key_label":0,"unicode":120,"location":0,"echo":false,"script":null)
+]
+}
+
 [rendering]
 
 renderer/rendering_method="gl_compatibility"


### PR DESCRIPTION
Closes #67 

I added an example of how to use the debug UI component in the main_menu.tscn scene. If you press X to bring up the debug UI and then click the hello_world button, it will execute debug_hello_world() and print a console message.