### PR TITLE
Add custom plugin to ensure correct version of godot is used

### DIFF
--- a/src/addons/version_check/plugin.cfg
+++ b/src/addons/version_check/plugin.cfg
@@ -1,0 +1,7 @@
+[plugin]
+
+name="Godot Version Checker"
+description="The Godot Version Checker is a plugin that enforces a specfic version of the Godot engine, minimising diffs between multiple contributors"
+author="Zephilinox"
+version="1.0.0"
+script="plugin.gd"

--- a/src/addons/version_check/plugin.gd
+++ b/src/addons/version_check/plugin.gd
@@ -1,0 +1,42 @@
+@tool
+extends EditorPlugin
+
+const SETTING_NAME := "version_check/required_version"
+
+func _get_current_version() -> String :
+    return "{major}.{minor}.{patch}".format(Engine.get_version_info())
+
+func _enter_tree() -> void:
+    _register_settings()
+    
+    var required_version := ProjectSettings.get_setting(SETTING_NAME)
+    var current_version := _get_current_version()
+
+    # incase someone only wants to check minor and not patch
+    if not current_version.begins_with(required_version):
+        _show_error("This project requires Godot Version '%s'\nYou are using Godot Version '%s'" %[required_version, current_version])
+
+func _register_settings():
+    if ProjectSettings.has_setting(SETTING_NAME):
+        return
+
+    var current_version := _get_current_version()
+
+    ProjectSettings.set_setting(SETTING_NAME, current_version)
+    ProjectSettings.add_property_info({
+        "name": SETTING_NAME,
+        "type": TYPE_STRING,
+        "hint": PROPERTY_HINT_NONE,
+        "usage": PROPERTY_USAGE_DEFAULT
+    })
+
+    ProjectSettings.save()
+
+func _show_error(err: String):
+    var dialog:= AcceptDialog.new()
+    dialog.dialog_text = err
+    dialog.title = "Invalid Godot Version"
+    get_editor_interface().get_editor_main_screen().add_child(dialog)
+    dialog.popup_centered()
+
+    push_error("Invalid Godot Version - %s" % err)

--- a/src/addons/version_check/plugin.gd.uid
+++ b/src/addons/version_check/plugin.gd.uid
@@ -1,0 +1,1 @@
+uid://ghxkxsl71pdw

--- a/src/project.godot
+++ b/src/project.godot
@@ -41,7 +41,7 @@ window/stretch/mode="canvas_items"
 
 [editor_plugins]
 
-enabled=PackedStringArray("res://addons/format_on_save/plugin.cfg", "res://addons/godot-logger/plugin.cfg", "res://addons/gut/plugin.cfg", "res://addons/panku_console/plugin.cfg")
+enabled=PackedStringArray("res://addons/format_on_save/plugin.cfg", "res://addons/godot-logger/plugin.cfg", "res://addons/gut/plugin.cfg", "res://addons/panku_console/plugin.cfg", "res://addons/version_check/plugin.cfg")
 
 [gui]
 
@@ -59,3 +59,7 @@ toggle_debug_popup={
 
 renderer/rendering_method="gl_compatibility"
 renderer/rendering_method.mobile="gl_compatibility"
+
+[version_check]
+
+required_version="4.4.1"


### PR DESCRIPTION
we saw some issues with tscn files being changed because of different Godot versions. hopefully this helps. It'll show a popup and print a console error, when the project is first opened in the editor. It isn't perfect, it can't "undo" any changes made by someone that opened it with the wrong version.

I chose not to force close the editor so that anyone with a slightly different version can still poke around and not get in the way too much, but if people ignore the popup and commit different files, we can change it

<img width="1488" height="710" alt="image" src="https://github.com/user-attachments/assets/ee8f071d-0796-4d0d-94e2-69fba4bda0c2" />
