### PR TITLE
Ignore the godot-git-plugin addon that not everyone will be using

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ builds/
 export.cfg
 export_credentials.cfg
 *.tscn*tmp
+src/addons/godot-git-plugin
 
 # Imported translations (automatically generated from CSV files)
 *.translation

--- a/scripts/disable_git_plugin.py
+++ b/scripts/disable_git_plugin.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+PROJECT_FILE = "src/project.godot"
+
+BLOCK = [
+    "\n",
+    "[editor]\n",
+    "\n",
+		'version_control/plugin_name="GitPlugin"\n',
+		'version_control/autoload_on_startup=true\n'
+]
+
+with open(PROJECT_FILE, "r", encoding="utf-8", newline="\n") as f:
+    lines = f.readlines()
+
+result = []
+i = 0
+while i < len(lines):
+    # Check if block matches starting at line i
+    if lines[i:i+len(BLOCK)] == BLOCK:
+        i += len(BLOCK)  # skip the block entirely
+    else:
+        result.append(lines[i])
+        i += 1
+
+with open(PROJECT_FILE, "w", encoding="utf-8", newline="\n") as f:
+    f.writelines(result)
+
+print(f"Removed exact block from {PROJECT_FILE} if present.")

--- a/scripts/enable_git_plugin.sh
+++ b/scripts/enable_git_plugin.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+PROJECT_FILE="src/project.godot"
+
+# Check if already present
+if grep -q "version_control" "$PROJECT_FILE"; then
+  echo "version_control already present in $PROJECT_FILE"
+  exit 0
+fi
+
+# Append the block to the file
+cat <<EOL >> "$PROJECT_FILE"
+
+[editor]
+
+version_control/plugin_name="GitPlugin"
+version_control/autoload_on_startup=true
+EOL
+
+echo "Added block to $PROJECT_FILE"


### PR DESCRIPTION
I added the godot-git-plugin addon to Godot locally, but probably not everyone will use it, so I added it as an ignore with some scripts to help me enable and disable it easily.