### PR TITLE
Update gdlintrc to ignore the addons folder when it's not running via precommit hooks

### DIFF
--- a/gdlintrc
+++ b/gdlintrc
@@ -24,6 +24,7 @@ enum-element-name: '[A-Z][A-Z0-9]*(_[A-Z0-9]+)*'
 enum-name: ([A-Z][a-z0-9]*)+
 excluded_directories: !!set
   .git: null
+  addons: null
 expression-not-assigned: null
 function-argument-name: _?[a-z][a-z0-9]*(_[a-z0-9]+)*
 function-arguments-number: 10


### PR DESCRIPTION
unfortunately gdlint doesn't yet have the technology to exclude specific directory paths, it only checks against the actual directory name, because that makes sense and no one could ever want something with more flexibility