### PR TITLE
Add workaround for direct Minigame start

### DIFF
--- a/src/modules/minigame/common/base_minigame.gd
+++ b/src/modules/minigame/common/base_minigame.gd
@@ -1,14 +1,18 @@
 class_name BaseMinigame
 extends Node
 
-var data: MinigameData
+@export var data: MinigameData
 
 var score: int
 
 
 func _ready() -> void:
-	assert(SceneLoader.current_minigame != null)
-	data = SceneLoader.current_minigame
+	if not SceneLoader.current_minigame:
+		push_warning("Detected direct Minigame start")
+		if data == null:
+			push_error("No MinigameData set")
+	else:
+		data = SceneLoader.current_minigame
 
 	open_menu()
 


### PR DESCRIPTION
BaseMinigame now allows you to export the MinigameData in the Minigame scene as a fallback for direct Minigame scene starts from the editor. 
As long as no upgrades are used, it will even work with no data assigned.