### PR TITLE
Fix minigame direct start

### DIFF
--- a/src/modules/minigame/common/base_minigame.gd
+++ b/src/modules/minigame/common/base_minigame.gd
@@ -1,6 +1,12 @@
+## Abstract class for Minigame root Node Scripts to inherit. Inherited Scripts
+## should override `_start()` instead of `_ready()` to start Minigames, so the
+## start procedure can be controlled from here.
 class_name BaseMinigame
 extends Node
 
+## Stores a uid reference to the MinigameData Resource.
+## This can be assigned manually so the Minigame scene is able to start
+## directly from the Editor, even when using `_start()` as entry point.
 @export var data_uid: String
 
 var data: MinigameData
@@ -21,12 +27,15 @@ func _ready() -> void:
 	open_menu()
 
 
-# virtual function for initializing the Minigame
+## Virtual function for initializing the Minigame. Inherited Scripts should
+## use this instead of `_init()` or `_ready()`, for any initialization logic
+## that can be run before the Minigame starts.
 func _initialize():
 	pass
 
 
-# virtual function for starting the Minigame
+## Virtual function for starting the Minigame. Inherited Scripts should
+## use this instead of `_ready()`.
 func _start():
 	pass
 

--- a/src/modules/minigame/common/base_minigame.gd
+++ b/src/modules/minigame/common/base_minigame.gd
@@ -1,7 +1,9 @@
 class_name BaseMinigame
 extends Node
 
-@export var data: MinigameData
+@export var data_uid: String
+
+var data: MinigameData
 
 var score: int
 
@@ -9,8 +11,10 @@ var score: int
 func _ready() -> void:
 	if not SceneLoader.has_current_minigame():
 		push_warning("Detected direct Minigame start")
-		if data == null:
-			push_error("No MinigameData set")
+		if data_uid.is_empty():
+			push_error("No data_uid set in the Minigame scene")
+		else:
+			data = load(data_uid)
 	else:
 		data = SceneLoader.get_current_minigame()
 

--- a/src/modules/minigame/example/minigame.tscn
+++ b/src/modules/minigame/example/minigame.tscn
@@ -30,6 +30,7 @@ metadata/_custom_type_script = "uid://bniv0kd24eb7w"
 
 [node name="Minigame" type="Node"]
 script = ExtResource("1_d7uj7")
+data_uid = "uid://dym4je2njvl28"
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 


### PR DESCRIPTION
In order to have the ability to start Minigames directly from the Editor and while Minigames using the proper start process by overriding `_start()` defined in `BaseMinigame` the MinigameData has to be referenced in the Minigames scene.

Before only the MinigameData held a reference to the Minigame scene. Since we are introducing a circular dependency now with the Scene referencing the Data and the Data referencing the Scene, this patch uses the MinigameDatas uid rather than the Resource itself in the `BaseMinigame`s export field.