### PR TITLE
Add upgrade button panel to debug UI

### DIFF
--- a/src/modules/debug/debug_popup.tscn
+++ b/src/modules/debug/debug_popup.tscn
@@ -33,6 +33,7 @@ grow_horizontal = 2
 text = "Debugging Shortcuts"
 
 [node name="ShortcutButtons" type="GridContainer" parent="."]
+unique_name_in_owner = true
 custom_minimum_size = Vector2(1000, 800)
 layout_mode = 1
 anchors_preset = 8
@@ -49,3 +50,39 @@ grow_vertical = 2
 theme_override_constants/h_separation = 10
 theme_override_constants/v_separation = 10
 columns = 3
+
+[node name="UpgradeButtons" type="GridContainer" parent="."]
+unique_name_in_owner = true
+custom_minimum_size = Vector2(1000, 800)
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -895.0
+offset_top = -400.0
+offset_right = 906.0
+offset_bottom = 400.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_constants/h_separation = 10
+theme_override_constants/v_separation = 20
+columns = 5
+
+[node name="Upgrades Button" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = -1
+anchor_left = 0.5
+anchor_top = 0.95
+anchor_right = 0.5
+anchor_bottom = 0.98
+offset_left = -4.0
+offset_top = -8.0
+offset_right = 4.0
+grow_horizontal = 2
+grow_vertical = 0
+toggle_mode = true
+text = "Upgrades"
+
+[connection signal="toggled" from="Upgrades Button" to="." method="_on_upgrades_button_toggled"]

--- a/src/modules/minigame/common/base_minigame.gd
+++ b/src/modules/minigame/common/base_minigame.gd
@@ -16,11 +16,15 @@ var score: int
 
 func _ready() -> void:
 	if not SceneLoader.has_current_minigame():
+		# Assumes this Minigame scene was started directly from the Editor
+		# Use workaround to set references as they would have been
+		# if the SceneLoader had been used
 		push_warning("Detected direct Minigame start")
 		if data_uid.is_empty():
 			push_error("No data_uid set in the Minigame scene")
 		else:
 			data = load(data_uid)
+			SceneLoader._current_minigame = data
 	else:
 		data = SceneLoader.get_current_minigame()
 

--- a/src/modules/minigame/common/minigame_data.gd
+++ b/src/modules/minigame/common/minigame_data.gd
@@ -17,3 +17,21 @@ extends Resource
 
 # stores the top n highscores
 @export_storage var high_scores: Array[int]
+
+
+## Returns all upgrades in the tree via recursion
+func get_all_upgrades(branch: BaseUpgrade = null) -> Array[BaseUpgrade]:
+	var result: Array[BaseUpgrade]
+	var root_nodes: Array[BaseUpgrade]
+
+	if branch:
+		root_nodes = branch.unlocks
+	else:
+		# Array type conversion BaseUpgrade <- upgrade_tree_root_nodes
+		root_nodes.assign(upgrade_tree_root_nodes)
+
+	for upgrade in root_nodes:
+		result.append(upgrade)
+		result.append_array(get_all_upgrades(upgrade))
+
+	return result

--- a/src/modules/minigame/example/minigame.gd
+++ b/src/modules/minigame/example/minigame.gd
@@ -14,8 +14,6 @@ func _init() -> void:
 
 
 func _start() -> void:
-	# start recursive display of upgrade layers
-	add_upgrade_layer(data.upgrade_tree_root_nodes, 1, Color.BLACK)
 	set_process(true)
 
 
@@ -26,45 +24,3 @@ func _process(delta: float) -> void:
 func on_upgrade_button_pressed(upgrade: MinigameUpgrade):
 	upgrade.level_up()
 	upgrade.logic._apply_effect(self, upgrade)
-
-
-# build dynamic upgrade UI with buttons
-func add_upgrade_layer(upgrades: Array[MinigameUpgrade], depth: int, color: Color):
-	# determine how deep we are in the tree and choose/create VBox Container
-	var vbox: VBoxContainer
-	if hbox.get_child_count() < depth:
-		vbox = VBoxContainer.new()
-		hbox.add_child(vbox)
-	else:
-		vbox = hbox.get_child(depth - 1)
-
-	# loop through all upgrades in this branch and create a Button for each
-	for upgrade in upgrades:
-		var button := Button.new()
-		button.text = upgrade.name
-		button.pressed.connect(on_upgrade_button_pressed.bind(upgrade))
-
-		# pick a color to differentiate branches
-		var branch_color: Color
-		if color == Color.BLACK:
-			branch_color = BRANCH_COLORS[upgrades.find(upgrade)]
-		else:
-			branch_color = color
-		button.add_theme_color_override("font_color", branch_color)
-
-		vbox.add_child(button)
-
-		# create another recursion for all upgrades unlocked by this upgrade
-		if not upgrade.unlocks.is_empty():
-			var unlocks: Array[MinigameUpgrade]
-			# convert Array type from BaseUpgrade to MinigameUpgrade
-			#
-			# this line was causing an error message
-			#unlocks.assign(upgrade.unlocks)
-			#
-			# so doing it manually below
-
-			for unlock in upgrade.unlocks:
-				unlocks.append(unlock)
-
-			add_upgrade_layer(unlocks, depth + 1, branch_color)


### PR DESCRIPTION
It's now possible to toggle an Upgrades panel in the Debug UI, that is automatically populated with buttons for all available Upgrades in this Minigame.

Buttons can be used to trigger individual Upgrades immediately.