### PR TITLE
Enable DebugPopup for builds

### DIFF
--- a/src/modules/debug/debug_popup.gd
+++ b/src/modules/debug/debug_popup.gd
@@ -10,7 +10,7 @@ extends Control
 
 # Set this to `false` if we want DebugPopup to work on release (non-debug) builds.
 # Recommended to leave this `true` so players can't cheat the final game.
-var _disable_on_release: bool = true
+var _disable_on_release: bool = false
 
 @onready var shortcut_buttons_container: GridContainer = %ShortcutButtons
 @onready var upgrade_buttons_container: GridContainer = %UpgradeButtons


### PR DESCRIPTION
This will let us see the placeholder "DebugPopup" menu on release builds.

Web build will be able to navigate to the minigames with this change.