### PR TITLE
Use tree for debug popup

### DIFF
--- a/src/modules/debug/debug_minigame_upgrades.gd
+++ b/src/modules/debug/debug_minigame_upgrades.gd
@@ -1,0 +1,53 @@
+class_name DebugMinigameUpgrades
+extends Node
+
+var _tree_upgrades: TreeItem
+var _tree_callables: Dictionary
+var _tree_root: TreeItem
+
+
+func set_tree(tree_callables: Dictionary, tree_root: TreeItem) -> void:
+	_tree_callables = tree_callables
+	_tree_root = tree_root
+
+
+func setup_upgrade_items():
+	assert(SceneLoader.has_current_minigame())
+
+	var data: MinigameData = SceneLoader.get_current_minigame()
+
+	_tree_upgrades = _tree_root.create_child()
+	_tree_upgrades.set_text(0, "Minigame upgrades")
+
+	for upgrade in data.get_all_upgrades():
+		_add_upgrade_item(upgrade)
+
+
+func _add_upgrade_item(upgrade: BaseUpgrade) -> void:
+	var new_item = _tree_upgrades.create_child()
+	var label = _get_upgrade_button_text(upgrade)
+	new_item.set_text(0, label)
+	var item_pressed = Callable(self, "_on_upgrade_item_pressed").bind(new_item, upgrade)
+	_tree_callables[new_item.get_instance_id()] = item_pressed
+	var hotkey = ""
+	# We can implement hotkeys for upgrade buttons, we just nxeed a place to
+	# define the key associated with a specific upgrade in BaseUpgrade.
+	if hotkey != "":
+		label = "[" + hotkey + "] " + label
+	else:
+		label = label
+
+
+func _get_upgrade_button_text(upgrade: BaseUpgrade) -> String:
+	return "%s Lvl %d" % [upgrade.name, upgrade.current_level + 1]
+
+
+func _on_upgrade_item_pressed(item: TreeItem, upgrade: BaseUpgrade):
+	upgrade.level_up()
+	if upgrade is MinigameUpgrade:
+		if upgrade.logic:
+			upgrade.logic._apply_effect(get_tree().current_scene, upgrade)
+	else:
+		assert(false, "Not implemented yet")
+
+	item.set_text(0, _get_upgrade_button_text(upgrade))

--- a/src/modules/debug/debug_minigame_upgrades.gd.uid
+++ b/src/modules/debug/debug_minigame_upgrades.gd.uid
@@ -1,0 +1,1 @@
+uid://8v2uyqjfeelx

--- a/src/modules/debug/debug_minigame_upgrades.tscn
+++ b/src/modules/debug/debug_minigame_upgrades.tscn
@@ -1,0 +1,3 @@
+[gd_scene format=3 uid="uid://cpiu2qu2fagua"]
+
+[node name="DebugMinigameUpgrades" type="Node2D"]

--- a/src/modules/debug/debug_minigame_upgrades.tscn
+++ b/src/modules/debug/debug_minigame_upgrades.tscn
@@ -1,3 +1,3 @@
-[gd_scene format=3 uid="uid://cpiu2qu2fagua"]
+[gd_scene load_steps=0 format=3 uid="uid://cpiu2qu2fagua"]
 
 [node name="DebugMinigameUpgrades" type="Node2D"]

--- a/src/modules/debug/debug_popup.gd
+++ b/src/modules/debug/debug_popup.gd
@@ -78,7 +78,12 @@ func _on_item_selected():
 	var selected: TreeItem = $Tree.get_selected()
 	if _tree_callables.has(selected.get_instance_id()):
 		$Tree.deselect_all()
-		_tree_callables[selected.get_instance_id()].call()
+		var callable: Callable = _tree_callables[selected.get_instance_id()]
+		# Why deferred?
+		# As a rule of thumb, never call change_scene* during the same frame
+		#  as GUI event handlers (e.g., _on_item_selected, _pressed,
+		# _input_event, etc.). Always defer or delay it.
+		callable.call_deferred()
 
 
 func _setup_item(debug_button: DebugButton, new_item: TreeItem) -> void:

--- a/src/modules/debug/debug_popup.gd
+++ b/src/modules/debug/debug_popup.gd
@@ -2,8 +2,14 @@ class_name DebugPopup
 
 extends Control
 
+# Title for the popup
+@export var title: String = "Debug"
+
 # Show the debug panel on start
 @export var visible_on_start: bool = false
+
+# Enable if this debug popup has minigame upgrades
+@export var has_minigame_upgrades: bool = false
 
 # Define debug buttons by providing the names of functions to call on press.
 @export var debug_buttons: Array[DebugButton] = []
@@ -12,8 +18,16 @@ extends Control
 # Recommended to leave this `true` so players can't cheat the final game.
 var _disable_on_release: bool = true
 
-@onready var shortcut_buttons_container: GridContainer = %ShortcutButtons
-@onready var upgrade_buttons_container: GridContainer = %UpgradeButtons
+# An array of dictionary objects with text_keycode and button properties.
+var _hotkeys: Array = []
+
+var _tree_root: TreeItem
+var _tree_shortcuts: TreeItem
+var _tree_callables: Dictionary = {}
+
+var _debug_minigame_upgrades: DebugMinigameUpgrades = (
+	preload("res://modules/debug/debug_minigame_upgrades.gd").new()
+)
 
 
 func _ready() -> void:
@@ -25,40 +39,78 @@ func _ready() -> void:
 	# By default, the debug popup is not visible. Press 'X' to bring it up.
 	visible = visible_on_start
 	position = Vector2.ZERO
+
+	_setup_shortcuts_tree()
 	_setup_debug_buttons()
+
+	if has_minigame_upgrades:
+		_setup_minigame_upgrades_buttons()
+
+
+func _setup_shortcuts_tree() -> void:
+	_tree_root = $Tree.create_item()
+	_tree_root.set_text(0, title)
+	_tree_shortcuts = _tree_root.create_child()
+	_tree_shortcuts.set_text(0, "Navigation and functions")
+	$Tree.connect("item_selected", _on_item_selected)
+
+
+func _setup_minigame_upgrades_buttons() -> void:
+	# Must have a minigame parent if enabling minigame upgrades
+	assert(get_parent() is BaseMinigame)
+	# Wait until the game scene is fully ready
+	get_parent().connect("game_scene_ready", _on_game_scene_ready)
+
+
+func _on_game_scene_ready() -> void:
+	add_child(_debug_minigame_upgrades)
+	_debug_minigame_upgrades.set_tree(_tree_callables, _tree_root)
+	_debug_minigame_upgrades.setup_upgrade_items()
 
 
 func _setup_debug_buttons() -> void:
 	for debug_button in debug_buttons:
-		var new_button = Button.new()
-		_add_button(debug_button, new_button)
-		shortcut_buttons_container.add_child(new_button)
+		var new_item = _tree_shortcuts.create_child()
+		_setup_item(debug_button, new_item)
 
 
-func _add_button(debug_button: DebugButton, new_button: Button) -> void:
+func _on_item_selected():
+	var selected: TreeItem = $Tree.get_selected()
+	if _tree_callables.has(selected.get_instance_id()):
+		$Tree.deselect_all()
+		_tree_callables[selected.get_instance_id()].call()
+
+
+func _setup_item(debug_button: DebugButton, new_item: TreeItem) -> void:
 	if debug_button.func_or_path.begins_with("res://"):
-		_add_change_scene_button(debug_button, new_button)
+		_add_change_scene_item(debug_button, new_item)
 	else:
-		_add_function_call_button(debug_button, new_button)
+		_add_function_call_item(debug_button, new_item)
 
 
-func _add_change_scene_button(debug_button: DebugButton, new_button: Button) -> void:
+func _add_change_scene_item(debug_button: DebugButton, new_item: TreeItem) -> void:
 	var scene_path = debug_button.func_or_path
 	var scene_filename = scene_path.get_file()
-	new_button.connect("pressed", Callable(self, "_change_scene").bind(scene_path))
+
+	var item_pressed = Callable(self, "_change_scene").bind(scene_path)
+	_tree_callables[new_item.get_instance_id()] = item_pressed
+
 	if debug_button.hotkey != "":
-		new_button.text = "[" + debug_button.hotkey + "] go to " + scene_filename
+		_hotkeys.append({"text_keycode": debug_button.hotkey, "callable": item_pressed})
+		new_item.set_text(0, "[" + debug_button.hotkey + "] go to " + scene_filename)
 	else:
-		new_button.text = "go to " + scene_filename
+		new_item.set_text(0, "go to " + scene_filename)
 
 
-func _add_function_call_button(debug_button: DebugButton, new_button: Button) -> void:
+func _add_function_call_item(debug_button: DebugButton, new_item: TreeItem) -> void:
 	var function_name = debug_button.func_or_path
-	new_button.connect("pressed", Callable(self, "_call_function").bind(function_name))
+	var item_pressed = Callable(self, "_call_function").bind(function_name)
+	_tree_callables[new_item.get_instance_id()] = item_pressed
 	if debug_button.hotkey != "":
-		new_button.text = "[" + debug_button.hotkey + "] " + function_name + "()"
+		_hotkeys.append({"text_keycode": debug_button.hotkey, "callable": item_pressed})
+		new_item.set_text(0, "[" + debug_button.hotkey + "] " + function_name + "()")
 	else:
-		new_button.text = function_name + "()"
+		new_item.set_text(0, function_name + "()")
 
 
 func _input(event: InputEvent) -> void:
@@ -68,12 +120,10 @@ func _input(event: InputEvent) -> void:
 	elif event is InputEventKey and event.is_pressed():
 		if visible:
 			print(event)
-		for debug_button in debug_buttons:
-			if debug_button.hotkey.to_lower() == event.as_text_keycode().to_lower():
-				if debug_button.func_or_path.begins_with("res://"):
-					_change_scene(debug_button.func_or_path)
-				else:
-					_call_function(debug_button.func_or_path)
+
+		for hotkey in _hotkeys:
+			if event.as_text_keycode().to_lower() == hotkey.text_keycode.to_lower():
+				hotkey.callable.call()
 
 
 func _call_function(function_name: String) -> void:
@@ -97,46 +147,3 @@ func _change_scene(scene_path: String) -> void:
 
 	print("Changing scene to: " + scene_path)
 	get_tree().change_scene_to_packed(load(scene_path))
-
-
-func _update_upgrade_buttons():
-	for child in upgrade_buttons_container.get_children():
-		upgrade_buttons_container.remove_child(child)
-		child.queue_free()
-
-	if not SceneLoader.has_current_minigame():
-		push_error("No MinigameData in SceneLoader")
-		return
-
-	var data: MinigameData = SceneLoader.get_current_minigame()
-
-	for upgrade in data.get_all_upgrades():
-		var button := Button.new()
-		_set_upgrade_button_text(button, upgrade)
-		button.pressed.connect(_on_upgrade_button_pressed.bind(button, upgrade))
-		upgrade_buttons_container.add_child(button)
-
-
-func _set_upgrade_button_text(button: Button, upgrade: BaseUpgrade):
-	button.text = "%s Lvl %d" % [upgrade.name, upgrade.current_level + 1]
-
-
-func _on_upgrade_button_pressed(button: Button, upgrade: BaseUpgrade):
-	upgrade.level_up()
-	if upgrade is MinigameUpgrade:
-		if upgrade.logic:
-			upgrade.logic._apply_effect(get_tree().current_scene, upgrade)
-	else:
-		assert(false, "Not implemented yet")
-
-	_set_upgrade_button_text(button, upgrade)
-
-
-func _on_upgrades_button_toggled(toggled_on: bool) -> void:
-	if toggled_on:
-		shortcut_buttons_container.hide()
-		_update_upgrade_buttons()
-		upgrade_buttons_container.show()
-	else:
-		upgrade_buttons_container.hide()
-		shortcut_buttons_container.show()

--- a/src/modules/debug/debug_popup.gd
+++ b/src/modules/debug/debug_popup.gd
@@ -3,7 +3,7 @@ class_name DebugPopup
 extends Control
 
 # Title for the popup
-@export var title: String = "Debug"
+@export var title: String = "DebugPopup"
 
 # Show the debug panel on start
 @export var visible_on_start: bool = false
@@ -49,7 +49,7 @@ func _ready() -> void:
 
 func _setup_shortcuts_tree() -> void:
 	_tree_root = $Tree.create_item()
-	_tree_root.set_text(0, title)
+	_tree_root.set_text(0, title + " (" + get_parent().name + ")")
 	_tree_shortcuts = _tree_root.create_child()
 	_tree_shortcuts.set_text(0, "Navigation and functions")
 	$Tree.connect("item_selected", _on_item_selected)

--- a/src/modules/debug/debug_popup.tscn
+++ b/src/modules/debug/debug_popup.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://bu3iegvrpg3ve" path="res://modules/debug/debug_popup.gd" id="1_gwiye"]
 
 [node name="DebugPopup" type="Control"]
+visible = false
 custom_minimum_size = Vector2(1920, 1080)
 layout_mode = 3
 anchors_preset = 15
@@ -12,78 +13,11 @@ grow_horizontal = 2
 grow_vertical = 2
 script = ExtResource("1_gwiye")
 
-[node name="ColorRect" type="ColorRect" parent="."]
+[node name="Tree" type="Tree" parent="."]
+custom_minimum_size = Vector2(500, 500)
 layout_mode = 1
-anchors_preset = 15
-anchor_right = 1.0
+anchors_preset = 9
 anchor_bottom = 1.0
-grow_horizontal = 2
+offset_right = 16.0
 grow_vertical = 2
-color = Color(0, 0, 0, 0.207843)
-
-[node name="Label" type="Label" parent="."]
-layout_mode = 1
-anchors_preset = 5
-anchor_left = 0.5
-anchor_right = 0.5
-offset_left = -180.5
-offset_right = 180.5
-offset_bottom = 50.0
-grow_horizontal = 2
-text = "Debugging Shortcuts"
-
-[node name="ShortcutButtons" type="GridContainer" parent="."]
-unique_name_in_owner = true
-custom_minimum_size = Vector2(1000, 800)
-layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -895.0
-offset_top = -400.0
-offset_right = 906.0
-offset_bottom = 400.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_constants/h_separation = 10
-theme_override_constants/v_separation = 10
-columns = 3
-
-[node name="UpgradeButtons" type="GridContainer" parent="."]
-unique_name_in_owner = true
-visible = false
-custom_minimum_size = Vector2(1000, 800)
-layout_mode = 1
-anchors_preset = 8
-anchor_left = 0.5
-anchor_top = 0.5
-anchor_right = 0.5
-anchor_bottom = 0.5
-offset_left = -895.0
-offset_top = -400.0
-offset_right = 906.0
-offset_bottom = 400.0
-grow_horizontal = 2
-grow_vertical = 2
-theme_override_constants/h_separation = 10
-theme_override_constants/v_separation = 20
-columns = 5
-
-[node name="Upgrades Button" type="Button" parent="."]
-layout_mode = 1
-anchors_preset = -1
-anchor_left = 0.5
-anchor_top = 0.95
-anchor_right = 0.5
-anchor_bottom = 0.98
-offset_left = -4.0
-offset_top = -8.0
-offset_right = 4.0
-grow_horizontal = 2
-grow_vertical = 0
-toggle_mode = true
-text = "Upgrades"
-
-[connection signal="toggled" from="Upgrades Button" to="." method="_on_upgrades_button_toggled"]
+theme_override_font_sizes/font_size = 21

--- a/src/modules/debug/debug_popup.tscn
+++ b/src/modules/debug/debug_popup.tscn
@@ -3,7 +3,6 @@
 [ext_resource type="Script" uid="uid://bu3iegvrpg3ve" path="res://modules/debug/debug_popup.gd" id="1_gwiye"]
 
 [node name="DebugPopup" type="Control"]
-visible = false
 custom_minimum_size = Vector2(1920, 1080)
 layout_mode = 3
 anchors_preset = 15

--- a/src/modules/menu/main_menu.tscn
+++ b/src/modules/menu/main_menu.tscn
@@ -32,7 +32,6 @@ metadata/_custom_type_script = "uid://bniv0kd24eb7w"
 script = ExtResource("1_tsonj")
 
 [node name="DebugPopup" parent="." instance=ExtResource("3_cvkr5")]
-visible = false
 anchors_preset = 0
 anchor_right = 0.0
 anchor_bottom = 0.0

--- a/src/modules/minigame/common/base_minigame.gd
+++ b/src/modules/minigame/common/base_minigame.gd
@@ -4,13 +4,14 @@
 class_name BaseMinigame
 extends Node
 
+signal game_scene_ready
+
 ## Stores a uid reference to the MinigameData Resource.
 ## This can be assigned manually so the Minigame scene is able to start
 ## directly from the Editor, even when using `_start()` as entry point.
 @export var data_uid: String
 
 var data: MinigameData
-
 var score: int
 
 
@@ -29,6 +30,8 @@ func _ready() -> void:
 		data = SceneLoader.get_current_minigame()
 
 	open_menu()
+
+	emit_signal("game_scene_ready")
 
 
 ## Virtual function for initializing the Minigame. Inherited Scripts should

--- a/src/modules/minigame/example/minigame.tscn
+++ b/src/modules/minigame/example/minigame.tscn
@@ -18,7 +18,7 @@ metadata/_custom_type_script = "uid://bniv0kd24eb7w"
 
 [sub_resource type="Resource" id="Resource_vsi1s"]
 script = ExtResource("3_vsi1s")
-func_or_path = "res://modules/menu/settings.tscn"
+func_or_path = "res://modules/settings/settings.tscn"
 hotkey = "s"
 metadata/_custom_type_script = "uid://bniv0kd24eb7w"
 
@@ -60,5 +60,6 @@ grow_horizontal = 2
 grow_vertical = 2
 
 [node name="DebugPopup" parent="." instance=ExtResource("2_ecuoj")]
-visible = false
+title = "Minigame Example"
+has_minigame_upgrades = true
 debug_buttons = Array[ExtResource("3_vsi1s")]([SubResource("Resource_5jsx0"), SubResource("Resource_ecuoj"), SubResource("Resource_vsi1s"), SubResource("Resource_be3yb")])


### PR DESCRIPTION
New version of DebugPopup - Ultimate Edition

* Now enhanced Tree view
* Ability to extend Tree view with collapsible new categories
* One click enable Minigame Upgrade category for minigames
* Easy to extend with new tools
* Can add tree items with editable values as well, if needed