### PR TITLE
Ignore hotkeys if Panku Console is open

### DIFF
--- a/src/modules/debug/debug_popup.gd
+++ b/src/modules/debug/debug_popup.gd
@@ -119,12 +119,17 @@ func _add_function_call_item(debug_button: DebugButton, new_item: TreeItem) -> v
 
 
 func _input(event: InputEvent) -> void:
+	# Ignore DebugPopup if the Panku shell is visible since the hotkeys
+	# will conflict with typing into the shell.
+	if Panku.get_shell_visibility():
+		return
+
 	if event.is_action_pressed("toggle_debug_popup"):
 		print("Toggling the DebugPopup")
 		visible = !visible
 	elif event is InputEventKey and event.is_pressed():
 		if visible:
-			print(event)
+			print("Pressed " + event.as_text_keycode())
 
 		for hotkey in _hotkeys:
 			if event.as_text_keycode().to_lower() == hotkey.text_keycode.to_lower():

--- a/src/modules/debug/debug_popup.tscn
+++ b/src/modules/debug/debug_popup.tscn
@@ -3,6 +3,7 @@
 [ext_resource type="Script" uid="uid://bu3iegvrpg3ve" path="res://modules/debug/debug_popup.gd" id="1_gwiye"]
 
 [node name="DebugPopup" type="Control"]
+z_index = 999
 custom_minimum_size = Vector2(1920, 1080)
 layout_mode = 3
 anchors_preset = 15


### PR DESCRIPTION
The hotkeys conflict with trying to type in the console.