### PR TITLE
Disable unused signal warnings in Godot

### DIFF
--- a/src/project.godot
+++ b/src/project.godot
@@ -34,6 +34,10 @@ GameSettings="*res://modules/settings/game_settings.gd"
 SceneLoader="*res://global/scene_loader.gd"
 Player="*res://global/player.gd"
 
+[debug]
+
+gdscript/warnings/unused_signal=0
+
 [debug_draw_3d]
 
 settings/addon_root_folder="res://addons/debug_draw_3d"


### PR DESCRIPTION
This warning is incompatible with the way we use signals in a global way in EventBus and most likely, many other places too written as strings rather than the direct signal name.

It's much better to disable this than:

* Add an annotation on every single event on EventBus
* Create dummy functions that have no purpose but to pretend we are using the signal

I think if someone really wants to, they can override this locally. But otherwise, this warning is spamming the console and harder to see the actual bugs and errors.

I'd like to get approvals from @Griiimon and @Zephilinox before merging.