### PR TITLE
Add DebugPopup to water target fishing minigame

### DIFF
--- a/src/modules/debug/debug_popup.gd
+++ b/src/modules/debug/debug_popup.gd
@@ -5,6 +5,9 @@ extends Control
 # Title for the popup
 @export var title: String = "DebugPopup"
 
+# Optional functions node where the callable functions live
+@export var functions_node: Node
+
 # Show the debug panel on start
 @export var visible_on_start: bool = false
 
@@ -32,6 +35,10 @@ func _ready() -> void:
 		visible = false
 		return
 
+	# By default, the functions_node is just the parent of this popup.
+	if !functions_node:
+		functions_node = get_parent()
+
 	# By default, the debug popup is not visible. Press 'X' to bring it up.
 	visible = visible_on_start
 	position = Vector2.ZERO
@@ -55,7 +62,7 @@ func link_callable(tree_item: TreeItem, callable: Callable) -> void:
 
 func _setup_shortcuts_tree() -> void:
 	_tree_root = $Tree.create_item()
-	_tree_root.set_text(0, title + " (" + get_parent().name + ")")
+	_tree_root.set_text(0, title + " (" + functions_node.name + ")")
 	_tree_shortcuts = _tree_root.create_child()
 	_tree_shortcuts.set_text(0, "Navigation and functions")
 
@@ -138,13 +145,12 @@ func _call_function(function_name: String) -> void:
 		push_error("No function name set for debug button.")
 		return
 
-	var parent = get_parent()
-	if parent == null:
+	if functions_node == null:
 		push_error("Missing parent node - cannot call function " + function_name + "()")
 		return
 
-	print("Calling " + parent.name + "." + function_name + "()")
-	parent.call(function_name)
+	print("Calling " + functions_node.name + "." + function_name + "()")
+	functions_node.call(function_name)
 
 
 func _change_scene(scene_path: String) -> void:

--- a/src/modules/minigame/fire_fighters/fire_fighters.tscn
+++ b/src/modules/minigame/fire_fighters/fire_fighters.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=3 uid="uid://dwdhfnts10fd0"]
+[gd_scene load_steps=19 format=3 uid="uid://dwdhfnts10fd0"]
 
 [ext_resource type="Script" uid="uid://bv6xign4t1vh5" path="res://modules/minigame/fire_fighters/fire_fighters_minigame.gd" id="1_k4ysf"]
 [ext_resource type="Texture2D" uid="uid://quxpeiq4tx62" path="res://assets/minigames/fire_fighters/placeholder_assets/terrain_tile_set.png" id="2_4r4fr"]
@@ -13,10 +13,7 @@
 [ext_resource type="Resource" uid="uid://dwfqr24woq5ie" path="res://modules/minigame/fire_fighters/data/burnt_tree.tres" id="9_o1kr5"]
 [ext_resource type="Resource" uid="uid://bhtwwe0fgwlob" path="res://modules/minigame/fire_fighters/data/boulder.tres" id="10_o1kr5"]
 [ext_resource type="PackedScene" uid="uid://oatd3ruxn0qu" path="res://modules/debug/debug_popup.tscn" id="13_eaqpl"]
-[ext_resource type="Script" uid="uid://bniv0kd24eb7w" path="res://modules/debug/debug_button.gd" id="14_ymaye"]
-[ext_resource type="Resource" uid="uid://b4sluedhgvlgp" path="res://modules/minigame/common/debug/exit_minigame.tres" id="15_0m1ww"]
 [ext_resource type="PackedScene" uid="uid://qofcdmvxcelc" path="res://modules/minigame/common/debug/debug_minigame_upgrades.tscn" id="15_ymaye"]
-[ext_resource type="Resource" uid="uid://cevq22684qul8" path="res://modules/minigame/common/debug/quit_game.tres" id="16_s1p25"]
 
 [sub_resource type="TileSetAtlasSource" id="TileSetAtlasSource_bkat1"]
 texture = ExtResource("2_4r4fr")
@@ -77,7 +74,6 @@ tile_set = SubResource("TileSet_prm31")
 visible = false
 offset_right = 1920.0
 offset_bottom = 1080.0
-debug_buttons = Array[ExtResource("14_ymaye")]([ExtResource("15_0m1ww"), ExtResource("16_s1p25")])
 
 [node name="DebugMinigameUpgrades" parent="DebugPopup" node_paths=PackedStringArray("debug_popup") instance=ExtResource("15_ymaye")]
 debug_popup = NodePath("..")

--- a/src/modules/minigame/water_target_fishing/water_target_fishing.tscn
+++ b/src/modules/minigame/water_target_fishing/water_target_fishing.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=15 format=3 uid="uid://dbvdwycj4dcgw"]
+[gd_scene load_steps=17 format=3 uid="uid://dbvdwycj4dcgw"]
 
 [ext_resource type="Script" uid="uid://blg15f2lyegrk" path="res://modules/minigame/water_target_fishing/water_target_fishing.gd" id="1_8oyae"]
 [ext_resource type="PackedScene" uid="uid://di5qytko63bu3" path="res://modules/minigame/water_target_fishing/game/entities/background_sprite.tscn" id="2_o5mdu"]
@@ -10,6 +10,8 @@
 [ext_resource type="PackedScene" uid="uid://brvr7tulxw60v" path="res://modules/minigame/water_target_fishing/game/camera2d.tscn" id="7_o5mdu"]
 [ext_resource type="PackedScene" uid="uid://dj70751qtb0ff" path="res://modules/minigame/water_target_fishing/game/components/generic/clear_colour.tscn" id="9_qq2lg"]
 [ext_resource type="Script" uid="uid://bpkdtrhrdt0xr" path="res://modules/minigame/water_target_fishing/game/fish_db.gd" id="10_c8m36"]
+[ext_resource type="PackedScene" uid="uid://oatd3ruxn0qu" path="res://modules/debug/debug_popup.tscn" id="11_n7mqc"]
+[ext_resource type="PackedScene" uid="uid://qofcdmvxcelc" path="res://modules/minigame/common/debug/debug_minigame_upgrades.tscn" id="12_m3rs1"]
 
 [sub_resource type="Gradient" id="Gradient_duxhx"]
 
@@ -811,6 +813,17 @@ theme_override_constants/outline_size = 8
 text = "0
 "
 fit_content = true
+
+[node name="DebugPopup" parent="CanvasLayer" node_paths=PackedStringArray("functions_node") instance=ExtResource("11_n7mqc")]
+visible = false
+top_level = true
+offset_right = 1920.0
+offset_bottom = 1080.0
+functions_node = NodePath("../..")
+
+[node name="DebugMinigameUpgrades" parent="CanvasLayer/DebugPopup" node_paths=PackedStringArray("debug_popup") instance=ExtResource("12_m3rs1")]
+visible = false
+debug_popup = NodePath("..")
 
 [node name="WTFFishDB" type="Node2D" parent="."]
 unique_name_in_owner = true


### PR DESCRIPTION
Adds the DebugPopup to the water target fishing minigame. Will let us return to the settlement with hotkeys in the normal game flow.