### PR TITLE
Fix narrowing conversion error

### DIFF
--- a/src/modules/upgrade/base_upgrade.gd
+++ b/src/modules/upgrade/base_upgrade.gd
@@ -95,7 +95,7 @@ func _construct_cost_and_modifier_arrays():
 	for i in range(max_level):
 		var new_cost: EssenceInventory = EssenceInventory.new()
 		for stack: EssenceStack in base_cost.slots:
-			var cost_calc: int = stack.amount * base_cost_multiplier * (i + 1)
+			var cost_calc: int = int(stack.amount * base_cost_multiplier * (i + 1))
 			new_cost.add_stack(EssenceStack.new(stack.essence, cost_calc))
 		cost_arr.append(new_cost)
 		effect_modifier_arr.append(base_effect_modifier * effect_modifier_multiplier * (i + 1))


### PR DESCRIPTION
Fixes the following error:

<img width="983" height="156" alt="image" src="https://github.com/user-attachments/assets/f4aefe92-fc35-47ed-8065-3bd7aaae2e1c" />

Please note, I don't know 100% if the value should be maintained as a float rather than casted as an int. So if that was wrong, please let me know.