### PR TITLE
Fix wrong path in resource for water target fishing minigame data

### DIFF
--- a/src/modules/overworld_locations/clayport/clayport.tscn
+++ b/src/modules/overworld_locations/clayport/clayport.tscn
@@ -6,7 +6,7 @@
 [ext_resource type="Resource" uid="uid://s7k08dgu5hxn" path="res://modules/minigame/earth_towers/data/earth_towers_data.tres" id="3_wnqv0"]
 [ext_resource type="Script" uid="uid://bniv0kd24eb7w" path="res://modules/debug/debug_button.gd" id="4_i3tw0"]
 [ext_resource type="Resource" uid="uid://ciyrdxjs03cvb" path="res://modules/minigame/water_diving/data/water_diving_data.tres" id="4_ue7jc"]
-[ext_resource type="Resource" uid="uid://jbisb8cm1037" path="res://modules/minigame/water_target_fishing/data/water_target_fishing_data.tres" id="5_0icjx"]
+[ext_resource type="Resource" uid="uid://c7vragnlq8udw" path="res://modules/minigame/water_target_fishing/data/water_fishing_data.tres" id="5_0icjx"]
 [ext_resource type="Resource" uid="uid://b50tc478quiok" path="res://modules/minigame/common/debug/overworld.tres" id="7_2h4su"]
 [ext_resource type="Resource" uid="uid://btgr85ek8vof0" path="res://modules/minigame/common/debug/settings.tres" id="8_0icjx"]
 [ext_resource type="Resource" uid="uid://cevq22684qul8" path="res://modules/minigame/common/debug/quit_game.tres" id="9_dt5ik"]


### PR DESCRIPTION
The filename needs to be updated here, as it was renamed in a previous PR.