### PR TITLE
Enhance upgrade tree plugin

### DIFF
--- a/src/addons/upgrade_tree/theme.tres
+++ b/src/addons/upgrade_tree/theme.tres
@@ -1,0 +1,4 @@
+[gd_resource type="Theme" format=3 uid="uid://bv6y6pwkl3t01"]
+
+[resource]
+default_font_size = 48

--- a/src/addons/upgrade_tree/upgrade_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_editor.gd
@@ -4,8 +4,55 @@ class_name UpgradeEditor
 
 @export var upgrade: MinigameUpgrade
 
+@onready var info: RichTextLabel =  %Information
+
+func _ready() -> void:
+	if upgrade:
+		position_offset = upgrade.position
+		set_fields_from_upgrade()
+
+
+func _process(delta: float) -> void:
+	set_fields_from_upgrade()
+
 
 func set_fields_from_upgrade() -> void:
+	assert(upgrade)
 	title = upgrade.name
-	position_offset = upgrade.position
 	$Control/Icon.texture = upgrade.icon
+
+	info.text = ""
+
+	if !upgrade.logic:
+		add_info_error("MISSING LOGIC")
+
+	if upgrade.cost_arr.is_empty():
+		add_info_error("MISSING COSTS")
+
+	if upgrade.max_level <= 0:
+		add_info_error("MISSING MAX LEVEL")
+
+	if !upgrade.effect_modifier_arr:
+		add_info_error("MISSING EFFECT MODIFIERS")
+
+	if upgrade.effect_modifier_arr.size() != upgrade.cost_arr.size():
+		add_info_error("MISMATCHED EFFECTS WITH COSTS")
+
+	if upgrade.flavor == "":
+		add_info_warning("MISSING FLAVOR")
+
+	if upgrade.description_prefix == "" || upgrade.description_suffix:
+		add_info_warning("MISSING DESCRIPTION")
+
+
+func add_info_error(msg: String) -> void:
+	add_info("[color=red]%s[/color]" % msg)
+
+func add_info_warning(msg: String) -> void:
+	add_info("[color=yellow]%s[/color]" % msg)
+
+func add_info(msg: String) -> void:
+	if info.text != "":
+		info.append_text("\n")
+
+	info.append_text("%s\n" %msg)

--- a/src/addons/upgrade_tree/upgrade_editor.tscn
+++ b/src/addons/upgrade_tree/upgrade_editor.tscn
@@ -1,11 +1,14 @@
-[gd_scene load_steps=2 format=3 uid="uid://oud0vpq34sev"]
+[gd_scene load_steps=3 format=3 uid="uid://oud0vpq34sev"]
 
+[ext_resource type="Theme" uid="uid://bv6y6pwkl3t01" path="res://addons/upgrade_tree/theme.tres" id="1_n60oh"]
 [ext_resource type="Script" uid="uid://beh2sx17yfvq7" path="res://addons/upgrade_tree/upgrade_editor.gd" id="1_npwrp"]
 
 [node name="UpgradeEditor" type="GraphNode"]
 offset_top = 1.0
-offset_right = 378.0
-offset_bottom = 401.0
+offset_right = 640.0
+offset_bottom = 641.0
+theme = ExtResource("1_n60oh")
+title = "<MISSING TITLE>"
 slot/0/left_enabled = true
 slot/0/left_type = 0
 slot/0/left_color = Color(1, 1, 1, 1)
@@ -15,6 +18,15 @@ slot/0/right_type = 0
 slot/0/right_color = Color(1, 1, 1, 1)
 slot/0/right_icon = null
 slot/0/draw_stylebox = true
+slot/1/left_enabled = false
+slot/1/left_type = 0
+slot/1/left_color = Color(1, 1, 1, 1)
+slot/1/left_icon = null
+slot/1/right_enabled = false
+slot/1/right_type = 0
+slot/1/right_color = Color(1, 1, 1, 1)
+slot/1/right_icon = null
+slot/1/draw_stylebox = true
 script = ExtResource("1_npwrp")
 
 [node name="Control" type="Control" parent="."]
@@ -23,3 +35,11 @@ layout_mode = 2
 [node name="Icon" type="Sprite2D" parent="Control"]
 position = Vector2(160, 151)
 scale = Vector2(0.5, 0.5)
+
+[node name="Information" type="RichTextLabel" parent="."]
+unique_name_in_owner = true
+layout_mode = 2
+theme = ExtResource("1_n60oh")
+bbcode_enabled = true
+text = "INFORMATION"
+fit_content = true

--- a/src/addons/upgrade_tree/upgrade_tree.tscn
+++ b/src/addons/upgrade_tree/upgrade_tree.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=0 format=3 uid="uid://cib0ln0mwn2a3"]
+[gd_scene format=3 uid="uid://cib0ln0mwn2a3"]
 
 [node name="UpgradeTreeEditor" type="Control"]
 layout_mode = 3
@@ -11,3 +11,4 @@ offset_top = -1.0
 offset_right = 1154.0
 offset_bottom = 646.0
 scroll_offset = Vector2(-40, -40)
+snapping_distance = 64

--- a/src/addons/upgrade_tree/upgrade_tree_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.gd
@@ -3,14 +3,84 @@ extends EditorPlugin
 
 const UpgradeTreeEditor = preload("res://addons/upgrade_tree/upgrade_tree_editor.tscn")
 const UpgradeEditorScene = preload("res://addons/upgrade_tree/upgrade_editor.tscn")
+const UpgradeTreeEditorVersion: int = 1
+const MissingCurrentDataText: StringName = "SELECT AN UPGRADE TREE"
 
-var upgrade_tree_editor_instance
+var upgrade_tree_editor_instance: Control
 var graph_edit: GraphEdit
 
 #FIXME: Need to handle this better when we have non-minigame trees
 var current_data: MinigameData = null
 var current_selected_node: GraphNode = null
 var file_dialog: FileDialog
+
+func _update_dropdown_trees():
+	var dropdown: OptionButton = upgrade_tree_editor_instance.get_node("UpgradeTreeDropdown")
+
+	var minigame_data_paths := _get_all_minigame_data("res://modules")
+	dropdown.clear()
+
+	if !current_data:
+		dropdown.add_item(MissingCurrentDataText)
+		dropdown.select(0)
+
+	for path in minigame_data_paths:
+		dropdown.add_item(path)
+
+	if current_data:
+		for idx in range(dropdown.item_count):
+			if dropdown.get_item_text(idx) == current_data.resource_path:
+				dropdown.select(idx)
+				break
+
+
+func _get_derived_classes(base_class: StringName) -> Array:
+	var result := []
+	var global_classes = ProjectSettings.get_global_class_list()
+
+	for class_info in global_classes:
+		print(class_info)
+		if class_info.base == base_class:
+			result.append(class_info.path)
+
+	return result
+
+
+func _get_class_path(name: String) -> String:
+	var result := []
+	var global_classes = ProjectSettings.get_global_class_list()
+
+	for class_info in global_classes:
+		print(class_info)
+		if class_info.class == name:
+			return class_info.path
+
+	assert(false)
+	return ""
+
+
+func _get_all_minigame_data(start_path:String) -> Array[String]:
+	var found_resources: Array[String] = []
+	var dir := DirAccess.open(start_path)
+	if not dir:
+		assert(false)
+		return found_resources
+
+	dir.list_dir_begin()
+	var file_name = dir.get_next()
+	while file_name != "":
+		if dir.current_is_dir():
+			if file_name != "." and file_name != "..":
+				found_resources.append_array(_get_all_minigame_data(start_path.path_join(file_name)))
+		else:
+			if file_name.ends_with(".tres") or file_name.ends_with(".res"):
+				var file_path = start_path.path_join(file_name)
+				var res = ResourceLoader.load(file_path)
+				if res and res is MinigameData:
+					found_resources.append(file_path)
+		file_name = dir.get_next()
+
+	return found_resources
 
 
 func _has_main_screen() -> bool:
@@ -21,8 +91,16 @@ func _make_visible(visible: bool) -> void:
 	if upgrade_tree_editor_instance:
 		if visible:
 			upgrade_tree_editor_instance.show()
+			_update_dropdown_trees()
 		else:
 			upgrade_tree_editor_instance.hide()
+
+		# stop all the upgrade nodes from updating, when we're not on that tab
+		var children := graph_edit.get_children()
+		for child in children:
+			var upgrade_editor: UpgradeEditor = child as UpgradeEditor
+			if upgrade_editor:
+				upgrade_editor.set_process(visible)
 
 
 func _get_plugin_name():
@@ -36,6 +114,9 @@ func _get_plugin_icon():
 func _enter_tree() -> void:
 	upgrade_tree_editor_instance = UpgradeTreeEditor.instantiate()
 	graph_edit = upgrade_tree_editor_instance.get_node("GraphEdit")
+	graph_edit.snapping_enabled = true
+	graph_edit.snapping_distance = 64
+	graph_edit.show_grid_buttons = false
 	graph_edit.right_disconnects = true
 	# Add the main panel to the editor's main viewport.
 	EditorInterface.get_editor_main_screen().add_child(upgrade_tree_editor_instance)
@@ -50,6 +131,9 @@ func _enter_tree() -> void:
 	)
 	upgrade_tree_editor_instance.get_node("ReloadResources").pressed.connect(
 		_on_reload_resources_pressed
+	)
+	upgrade_tree_editor_instance.get_node("UpgradeTreeDropdown").item_selected.connect(
+		_on_tree_dropdown_selected
 	)
 	graph_edit.connection_request.connect(_on_connection_request)
 	graph_edit.disconnection_request.connect(_on_disconnection_request)
@@ -116,6 +200,7 @@ func _clear_upgrade_tree() -> void:
 #FIXME: Need to handle this better when we have non-minigame trees
 func _save_upgrade(upgrade: MinigameUpgrade):
 	if upgrade.resource_path:
+		upgrade.set_meta("tree_editor_version_saved", UpgradeTreeEditorVersion)
 		ResourceSaver.save(upgrade)
 	else:
 		print("Warning: resource path not set. Changes not being saved")
@@ -128,11 +213,21 @@ func _on_add_upgrade_pressed() -> void:
 	#FIXME: Need to handle this better when we have non-minigame trees
 	if current_data is MinigameData:
 		var upgrade = MinigameUpgrade.new()
+		# we can use this in the future to update old upgrades or something
+		# a lil bit of future proofing never hurt innit
+		upgrade.set_meta("tree_editor_version_added", UpgradeTreeEditorVersion)
 		upgrade.name = "New Upgrade"
+		upgrade.position = Vector2(0, 0)
+
 		if current_selected_node:
-			upgrade.position = current_selected_node.position_offset + Vector2(50, 50)
-		else:
-			upgrade.position = Vector2(100, 100)
+			upgrade.position = current_selected_node.position_offset + Vector2(128, 128)
+
+			var upgrade_editor_node := current_selected_node as UpgradeEditor
+			if upgrade_editor_node:
+				upgrade.logic = upgrade_editor_node.upgrade.logic
+				upgrade.max_level = upgrade_editor_node.upgrade.max_level
+
+		# explicitly passing null because it auto-connects and that's kinda frustrating tbh
 		_add_node(graph_edit, upgrade, null)
 	else:
 		push_error("No MiniGameData selected.")
@@ -165,21 +260,23 @@ func _on_file_selected(path: String) -> void:
 	ResourceSaver.save(current_selected_node.upgrade)
 
 
-# Signal Handlers
-
-
-func _on_edited_object_changed() -> void:
-	var edited = EditorInterface.get_inspector().get_edited_object()
+func change_tree(object: Variant) -> void:
 	#FIXME: Need to handle this better when we have non-minigame trees
-	if edited is MinigameData:
-		current_data = edited
+	if object is MinigameData:
+		current_data = object
 		_draw_upgrade_tree(current_data)
 		_make_visible(true)
-	elif not edited is BaseUpgrade:
+	elif not object is BaseUpgrade:
 		current_data = null
 		current_selected_node = null
 		_clear_upgrade_tree()
 		_make_visible(false)
+
+
+# Signal Handlers
+func _on_edited_object_changed() -> void:
+	var edited = EditorInterface.get_inspector().get_edited_object()
+	change_tree(edited)
 
 
 func _on_upgrade_selected(graph_node: GraphNode) -> void:
@@ -211,3 +308,11 @@ func _on_connection_request(from_node, from_port, to_node, to_port):
 	from_node_instance.upgrade.unlocks.append(to_node_instance.upgrade)
 	_save_upgrade(from_node_instance.upgrade)
 	graph_edit.connect_node(from_node, from_port, to_node, to_port)
+
+
+func _on_tree_dropdown_selected(index: int) -> void:
+	var dropdown: OptionButton = upgrade_tree_editor_instance.get_node("UpgradeTreeDropdown")
+	if dropdown.get_item_text(index) == MissingCurrentDataText:
+		return
+
+	change_tree(load(dropdown.get_item_text(index)))

--- a/src/addons/upgrade_tree/upgrade_tree_editor.tscn
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.tscn
@@ -49,3 +49,12 @@ offset_right = 1151.0
 offset_bottom = 65.0
 theme_override_font_sizes/font_size = 18
 text = "Reload resources"
+
+[node name="UpgradeTreeDropdown" type="OptionButton" parent="."]
+layout_mode = 0
+offset_left = 17.0
+offset_top = 96.0
+offset_right = 220.0
+offset_bottom = 147.0
+tooltip_text = "Select an upgrade tree"
+allow_reselect = true


### PR DESCRIPTION
it has taken me ages to get a lot of this stuff working... sorry if I've forgotten a chance, it's late 😭 

- change snapping distance and hide the button so everyone needs to snap
- 64px snap distance, should match our in-game icon resolutions
- added a theme so the font on the nodes is nice and big
- added errors and warnings to them, to tell people about dodgy nodes in their tree
- automatically updates the nodes in the tree based on changes made to their resource files via the inspector
- adds metadata to the data resources so we can track what version of the plugin was used to create or save them, could be handy

and the actual reasons I wanted to make some changes (a.k.a omfg, doing this manually is a pain, how hard could it be to get the plugin to do it for me)

- added a dropdown to select which upgrade tree to edit, instead of needing to find it in the filesystem. also tells you when you have no tree selected
- automatically sets the upgrade logic of a node based on the previous one selected