### PR TITLE
Apply all unlocked upgrades on Minigame start

### DIFF
--- a/src/modules/minigame/common/base_minigame.gd
+++ b/src/modules/minigame/common/base_minigame.gd
@@ -77,15 +77,8 @@ func _start():
 # It should run the minigame.
 func play():
 	_initialize()
-	_apply_all_upgrades()
+	data.apply_all_upgrades(self)
 	_start()
-
-
-func _apply_all_upgrades():
-	for upgrade in data.get_all_upgrades(null, true):
-		var minigame_upgrade: MinigameUpgrade = upgrade
-		assert(minigame_upgrade.logic != null)
-		minigame_upgrade.logic._apply_effect(self, upgrade)
 
 
 func add_score(n: int = 1):

--- a/src/modules/minigame/common/base_minigame.gd
+++ b/src/modules/minigame/common/base_minigame.gd
@@ -77,7 +77,15 @@ func _start():
 # It should run the minigame.
 func play():
 	_initialize()
+	_apply_all_upgrades()
 	_start()
+
+
+func _apply_all_upgrades():
+	for upgrade in data.get_all_upgrades(null, true):
+		var minigame_upgrade: MinigameUpgrade = upgrade
+		assert(minigame_upgrade.logic != null)
+		minigame_upgrade.logic._apply_effect(self, upgrade)
 
 
 func add_score(n: int = 1):

--- a/src/modules/minigame/earth_potato_herding/earth_potato_herding.gd
+++ b/src/modules/minigame/earth_potato_herding/earth_potato_herding.gd
@@ -20,7 +20,6 @@ func _initialize() -> void:
 	spirit_keeper_brightness.emit(0.0)
 	spirit_keeper_speed.emit(0.0)
 	nutritious_potato.connect(_on_nutrition_changed)
-	data.apply_all_upgrades(self)
 
 
 func _on_nutrition_changed(modifier: float):

--- a/src/modules/minigame/example/minigame.gd
+++ b/src/modules/minigame/example/minigame.gd
@@ -19,8 +19,3 @@ func _start() -> void:
 
 func _process(delta: float) -> void:
 	circle_center.rotate(rotation_speed * delta)
-
-
-func on_upgrade_button_pressed(upgrade: MinigameUpgrade):
-	upgrade.level_up()
-	upgrade.logic._apply_effect(self, upgrade)


### PR DESCRIPTION
This will apply all unlocked upgrades automatically when the Minigame is started.

It will apply them after `_initialize()` but before `_start()`, so make sure everything that upgrades can apply an effect to is initialized and instantiated.