### PR TITLE
Fix inaccessible score property in water target fishing game

### DIFF
--- a/src/modules/minigame/water_target_fishing/game/entities/player.gd
+++ b/src/modules/minigame/water_target_fishing/game/entities/player.gd
@@ -37,7 +37,7 @@ func _on_area_entered(other_area: Area2D) -> void:
 
 	var maybe_fish := other_area.get_parent() as WTFFish
 	if is_instance_valid(maybe_fish):
-		WTFGlobals.minigame.score += maybe_fish.data.pickup.score
+		WTFGlobals.minigame.add_score(maybe_fish.data.pickup.score)
 		TextFloatSystem.floating_text(
 			maybe_fish.global_position, "+%d" % maybe_fish.data.pickup.score, WTFGlobals.minigame
 		)

--- a/src/modules/minigame/water_target_fishing/game/entities/player.gd
+++ b/src/modules/minigame/water_target_fishing/game/entities/player.gd
@@ -49,7 +49,7 @@ func _on_area_entered(other_area: Area2D) -> void:
 
 	var maybe_cannon = other_area.get_parent() as WTFJetCannon
 	if is_instance_valid(maybe_cannon):
-		WTFGlobals.minigame.score += maybe_cannon.pickup.score
+		WTFGlobals.minigame.add_score(maybe_cannon.pickup.score)
 		TextFloatSystem.floating_text(
 			maybe_cannon.global_position, "+%d" % maybe_cannon.pickup.score, WTFGlobals.minigame
 		)

--- a/src/modules/minigame/water_target_fishing/water_target_fishing.gd
+++ b/src/modules/minigame/water_target_fishing/water_target_fishing.gd
@@ -44,7 +44,7 @@ func _start() -> void:
 
 func _process(_delta: float) -> void:
 	ui_speed_value.text = str(get_pixels_per_second())
-	ui_score_value.text = str(score)
+	ui_score_value.text = str(get_score())
 	ui_oxygen_value.text = str(WTFGlobals.minigame.stats.oxygen_percentage()) + "%"
 	ui_weight_value.text = str(floori(stats.total_weight()))
 	ui_distance_value.text = str(floori(_distance_travelled))


### PR DESCRIPTION
Makes the water game not crash when it hits one of those scoring things