### PR TITLE
Fix for errors in our CI/CD about leaked resources

### DIFF
--- a/src/modules/minigame/common/minigame_data.gd
+++ b/src/modules/minigame/common/minigame_data.gd
@@ -20,11 +20,9 @@ extends Resource
 
 
 ## Returns all upgrades in the tree via recursion
-func get_all_upgrades(
-	branch: BaseUpgrade = null, unlocked_only: bool = false
-) -> Array[BaseUpgrade]:
-	var result: Array[BaseUpgrade]
-	var root_nodes: Array[BaseUpgrade]
+func get_all_upgrades(branch: BaseUpgrade = null, unlocked_only: bool = false) -> Array[Resource]:
+	var result: Array[Resource]
+	var root_nodes: Array[Resource]
 
 	if branch:
 		root_nodes = branch.unlocks

--- a/src/modules/upgrade/base_upgrade.gd
+++ b/src/modules/upgrade/base_upgrade.gd
@@ -56,7 +56,7 @@ enum ModifierFormat { PERCENTAGE, ADDITIVE, MULTIPLIER }
 @export var unlock_level: int
 
 ## Upgrades that can get unlocked by this one
-@export var unlocks: Array[BaseUpgrade]
+@export var unlocks: Array[Resource]
 
 @export_category("Description")
 


### PR DESCRIPTION
This PR fixes the following issue:

<img width="1486" height="454" alt="Screenshot from 2025-08-05 12-45-27" src="https://github.com/user-attachments/assets/d781b747-6f42-468f-bdd3-8dde7df26250" />

With this clean up, we can let our CI/CD fail when we detect any error message.

Unfortunately, we lose the static type check but we can add a dynamic assert() somewhere if we really want to.