### PR TITLE
Disable unused variables until we have them being used in the script

### DIFF
--- a/src/modules/minigame/common/shared/minigame_overlay.gd
+++ b/src/modules/minigame/common/shared/minigame_overlay.gd
@@ -10,13 +10,13 @@ extends PanelContainer
 		_countdown_panel.visible = b
 
 @onready var _score_panel: HBoxContainer = %ScorePanel
-@onready var _score_label: Label = %ScoreLabel
-@onready var _score_icon: TextureRect = %ScoreIcon
+#@onready var _score_label: Label = %ScoreLabel
+#@onready var _score_icon: TextureRect = %ScoreIcon
 @onready var _score_value: Label = %ScoreValue
 
 @onready var _countdown_panel: HBoxContainer = %CountdownPanel
-@onready var _countdown_label: Label = %CountdownLabel
-@onready var _countdown_icon: TextureRect = %CountdownIcon
+#@onready var _countdown_label: Label = %CountdownLabel
+#@onready var _countdown_icon: TextureRect = %CountdownIcon
 @onready var _countdown_value: Label = %CountdownValue
 
 


### PR DESCRIPTION
Fixes the failing unit tests in our CICD

<img width="846" height="424" alt="Screenshot from 2025-08-05 17-11-26" src="https://github.com/user-attachments/assets/45a85342-1cc4-4df4-8d86-ed288987a0af" />
