### PR TITLE
Remove unnecessary export vars from shared Minigame components

### DIFF
--- a/src/modules/menu/minigame_menu.gd
+++ b/src/modules/menu/minigame_menu.gd
@@ -2,11 +2,15 @@ class_name MinigameMenu
 extends Control
 
 @export var visible_on_start: bool = false
-@export var minigame: BaseMinigame
 @export var pause: Pause
+
+var minigame: BaseMinigame
 
 
 func _ready() -> void:
+	minigame = get_tree().current_scene
+	assert(minigame != null)
+
 	assert(
 		minigame is BaseMinigame,
 		(

--- a/src/modules/minigame/common/shared/minigame_shared.gd
+++ b/src/modules/minigame/common/shared/minigame_shared.gd
@@ -1,14 +1,18 @@
 class_name MinigameSharedComponents
 extends Node
 
-@export var minigame_node: BaseMinigame
 @export var debug_popup: DebugPopup
 @export var game_popup_menu: GamePopupMenu
 @export var minigame_menu: MinigameMenu
 @export var minigame_overlay: MinigameOverlay
 
+var minigame_node: BaseMinigame
+
 
 func _ready():
+	minigame_node = get_parent()
+	assert(minigame_node != null)
+
 	debug_popup.functions_node = minigame_node
 	game_popup_menu.visible = false
 

--- a/src/modules/minigame/earth_potato_herding/earth_potato_herding.tscn
+++ b/src/modules/minigame/earth_potato_herding/earth_potato_herding.tscn
@@ -92,11 +92,7 @@ texture = ExtResource("5_ojsc6")
 [node name="EPHPlayer" parent="." instance=ExtResource("7_00m8t")]
 position = Vector2(571, 596)
 
-[node name="MinigameSharedComponents" parent="." node_paths=PackedStringArray("minigame_node") instance=ExtResource("11_eeopq")]
-minigame_node = NodePath("..")
-
-[node name="MinigameMenu" parent="MinigameSharedComponents/SharedBaseComponents/CanvasLayer" index="0" node_paths=PackedStringArray("minigame")]
-minigame = NodePath("../../../..")
+[node name="MinigameSharedComponents" parent="." instance=ExtResource("11_eeopq")]
 
 [node name="DebugPopup" parent="MinigameSharedComponents/SharedBaseComponents/CanvasLayer" index="1" node_paths=PackedStringArray("functions_node")]
 visible = false

--- a/src/modules/minigame/earth_tower_tumble/earth_tower_tumble.tscn
+++ b/src/modules/minigame/earth_tower_tumble/earth_tower_tumble.tscn
@@ -162,11 +162,7 @@ script = ExtResource("14_uvjps")
 position = Vector2(0, 239)
 shape = SubResource("RectangleShape2D_wlaab")
 
-[node name="SharedComponents" parent="." node_paths=PackedStringArray("minigame_node") instance=ExtResource("2_0yx17")]
-minigame_node = NodePath("..")
-
-[node name="MinigameMenu" parent="SharedComponents/SharedBaseComponents/CanvasLayer" index="0" node_paths=PackedStringArray("minigame")]
-minigame = NodePath("../../../..")
+[node name="SharedComponents" parent="." instance=ExtResource("2_0yx17")]
 
 [node name="DebugPopup" parent="SharedComponents/SharedBaseComponents/CanvasLayer" index="1" node_paths=PackedStringArray("functions_node")]
 functions_node = NodePath("../../../..")

--- a/src/modules/minigame/example/minigame.tscn
+++ b/src/modules/minigame/example/minigame.tscn
@@ -34,11 +34,7 @@ offset_bottom = 20.0
 grow_horizontal = 2
 grow_vertical = 2
 
-[node name="SharedComponents" parent="." node_paths=PackedStringArray("minigame_node") instance=ExtResource("2_0gqa2")]
-minigame_node = NodePath("..")
-
-[node name="MinigameMenu" parent="SharedComponents/SharedBaseComponents/CanvasLayer" index="0" node_paths=PackedStringArray("minigame")]
-minigame = NodePath("../../../..")
+[node name="SharedComponents" parent="." instance=ExtResource("2_0gqa2")]
 
 [node name="DebugPopup" parent="SharedComponents/SharedBaseComponents/CanvasLayer" index="1" node_paths=PackedStringArray("functions_node")]
 functions_node = NodePath("../../../..")

--- a/src/modules/minigame/fire_cooking/fire_cooking.tscn
+++ b/src/modules/minigame/fire_cooking/fire_cooking.tscn
@@ -7,11 +7,7 @@
 script = ExtResource("1_bvapi")
 data_uid = "uid://bseyt0iuwnq5m"
 
-[node name="SharedComponents" parent="." node_paths=PackedStringArray("minigame_node") instance=ExtResource("4_bvapi")]
-minigame_node = NodePath("..")
-
-[node name="MinigameMenu" parent="SharedComponents/SharedBaseComponents/CanvasLayer" index="0" node_paths=PackedStringArray("minigame")]
-minigame = NodePath("../../../..")
+[node name="SharedComponents" parent="." instance=ExtResource("4_bvapi")]
 
 [node name="DebugPopup" parent="SharedComponents/SharedBaseComponents/CanvasLayer" index="1" node_paths=PackedStringArray("functions_node")]
 functions_node = NodePath("../../../..")

--- a/src/modules/minigame/fire_fighters/fire_fighters.tscn
+++ b/src/modules/minigame/fire_fighters/fire_fighters.tscn
@@ -76,11 +76,7 @@ tile_set = SubResource("TileSet_prm31")
 
 [node name="Fires" type="Node" parent="."]
 
-[node name="SharedComponents" parent="." node_paths=PackedStringArray("minigame_node") instance=ExtResource("13_a330y")]
-minigame_node = NodePath("..")
-
-[node name="MinigameMenu" parent="SharedComponents/SharedBaseComponents/CanvasLayer" index="0" node_paths=PackedStringArray("minigame")]
-minigame = NodePath("../../../..")
+[node name="SharedComponents" parent="." instance=ExtResource("13_a330y")]
 
 [node name="DebugPopup" parent="SharedComponents/SharedBaseComponents/CanvasLayer" index="1" node_paths=PackedStringArray("functions_node")]
 functions_node = NodePath("../../../..")

--- a/src/modules/minigame/water_diving/water_diving.tscn
+++ b/src/modules/minigame/water_diving/water_diving.tscn
@@ -7,11 +7,7 @@
 script = ExtResource("1_jjxx3")
 data_uid = "uid://ciyrdxjs03cvb"
 
-[node name="SharedComponents" parent="." node_paths=PackedStringArray("minigame_node") instance=ExtResource("2_7tndl")]
-minigame_node = NodePath("..")
-
-[node name="MinigameMenu" parent="SharedComponents/SharedBaseComponents/CanvasLayer" index="0" node_paths=PackedStringArray("minigame")]
-minigame = NodePath("../../../..")
+[node name="SharedComponents" parent="." instance=ExtResource("2_7tndl")]
 
 [node name="DebugPopup" parent="SharedComponents/SharedBaseComponents/CanvasLayer" index="1" node_paths=PackedStringArray("functions_node")]
 functions_node = NodePath("../../../..")

--- a/src/modules/minigame/water_target_fishing/water_target_fishing.tscn
+++ b/src/modules/minigame/water_target_fishing/water_target_fishing.tscn
@@ -819,14 +819,10 @@ script = ExtResource("10_c8m36")
 directory_path = "res://modules/minigame/water_target_fishing/game/data/fish"
 metadata/_custom_type_script = "uid://bpkdtrhrdt0xr"
 
-[node name="SharedComponents" parent="." node_paths=PackedStringArray("minigame_node") instance=ExtResource("11_56cph")]
-minigame_node = NodePath("..")
+[node name="SharedComponents" parent="." instance=ExtResource("11_56cph")]
 
 [node name="SharedBaseComponents" parent="SharedComponents" index="1"]
 allow_popup_menu = null
-
-[node name="MinigameMenu" parent="SharedComponents/SharedBaseComponents/CanvasLayer" index="0" node_paths=PackedStringArray("minigame")]
-minigame = NodePath("../../../..")
 
 [node name="DebugPopup" parent="SharedComponents/SharedBaseComponents/CanvasLayer" index="1" node_paths=PackedStringArray("functions_node")]
 functions_node = NodePath("../../../..")


### PR DESCRIPTION
The shared Minigame component will, and _should_, always be a direct child of a Minigame scene, so the shared components can acquire a reference to the Minigame node automatically.

This will also reduce the chance of merge conflicts in Minigame scene files.