### PR TITLE
Add inventory stack management methods to EssenceInventory

### DIFF
--- a/src/modules/essence/essence_inventory.gd
+++ b/src/modules/essence/essence_inventory.gd
@@ -81,4 +81,35 @@ func get_essence(essence: Essence) -> int:
 
 	return 0
 
+
+# merges stacks from inventories a & b into caller
+func merge(other: EssenceInventory):
+	for stack in other.slots:
+		add_stack(stack)
+
+
+# returns true if a stacks of a certain essence are available
+func has_stack(stack: EssenceStack) -> bool:
+	for i in slots:
+		if i.essence == stack.essence:
+			return true
+	return false
+
+
+# assuming we'll use this to check calling inv has enough for something
+func has_inventory(other: EssenceInventory) -> bool:
+	for stack in other.slots:
+		if get_essence(stack.essence) < stack.amount:
+			return false
+	return true
+
+
+func sub_stack(stack: EssenceStack, amount: int):  # Removes x amount of essence from a given stack
+	for slot in slots:
+		if slot.essence == stack.essence:
+			slot.amount -= amount
+			if slot.amount <= 0:
+				slots.erase(slot)
+			return
+
 # TODO sub_stack, has_essence, has_stack, merge, ...

--- a/src/modules/minigame/earth_tower_tumble/earth_tower_tumble.tscn
+++ b/src/modules/minigame/earth_tower_tumble/earth_tower_tumble.tscn
@@ -9,11 +9,11 @@
 [ext_resource type="Script" uid="uid://bqkp2jhuqul2q" path="res://modules/minigame/earth_tower_tumble/block_spawner.gd" id="6_sfu5h"]
 [ext_resource type="Texture2D" uid="uid://b0578meoknrrg" path="res://assets/icons/basket_in_circle_skn.png" id="7_hwnjf"]
 [ext_resource type="Texture2D" uid="uid://b7o48p71vs2yc" path="res://assets/minigames/earth_tower_tumble/background.png" id="9_e1brv"]
-[ext_resource type="Script" uid="uid://b70epgha4rake" path="res://modules/minigame/earth_tower_tumble/parallax_background.gd" id="9_kc8as"]
+[ext_resource type="Script" path="res://modules/minigame/earth_tower_tumble/parallax_background.gd" id="9_kc8as"]
 [ext_resource type="Script" uid="uid://bdxiechv2n4ff" path="res://modules/minigame/earth_tower_tumble/player.gd" id="9_yt77r"]
 [ext_resource type="Texture2D" uid="uid://dem6aslg0cdbs" path="res://assets/minigames/earth_tower_tumble/clouds.png" id="10_e1brv"]
 [ext_resource type="Texture2D" uid="uid://c02dayueobaw" path="res://assets/minigames/earth_tower_tumble/hearts_full.png" id="12_hn5om"]
-[ext_resource type="Script" uid="uid://l0gnaweii5w6" path="res://modules/minigame/earth_tower_tumble/fall_zone.gd" id="14_uvjps"]
+[ext_resource type="Script" path="res://modules/minigame/earth_tower_tumble/fall_zone.gd" id="14_uvjps"]
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_uvjps"]
 shader = ExtResource("5_wlaab")


### PR DESCRIPTION
Implemented merge, has_stack, has_inventory, and sub_stack methods in essence_inventory.gd to support stack merging, presence checks, and stack subtraction.

Wasn't 100% sure based on naming what each would should do, but went with these