### PR TITLE
Upgrade tree editor changes

### DIFF
--- a/src/addons/upgrade_tree/upgrade_tree_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.gd
@@ -30,7 +30,9 @@ func _update_dropdown_trees():
 	if current_data:
 		for idx in range(dropdown.item_count):
 			if dropdown.get_item_text(idx) == current_data.resource_path:
+				# for some reason this doesn't call the signal, so we draw the tree
 				dropdown.select(idx)
+				_draw_upgrade_tree(current_data)
 				break
 
 
@@ -100,19 +102,21 @@ func _has_main_screen() -> bool:
 
 
 func _make_visible(visible: bool) -> void:
-	if upgrade_tree_editor_instance:
-		if visible:
-			upgrade_tree_editor_instance.show()
-			_update_dropdown_trees()
-		else:
-			upgrade_tree_editor_instance.hide()
+	if !upgrade_tree_editor_instance:
+		return
 
-		# stop all the upgrade nodes from updating, when we're not on that tab
-		var children := graph_edit.get_children()
-		for child in children:
-			var upgrade_editor: UpgradeEditor = child as UpgradeEditor
-			if upgrade_editor:
-				upgrade_editor.set_process(visible)
+	if visible:
+		upgrade_tree_editor_instance.show()
+		_update_dropdown_trees()
+	else:
+		upgrade_tree_editor_instance.hide()
+
+	# stop all the upgrade nodes from updating, when we're not on that tab
+	var children := graph_edit.get_children()
+	for child in children:
+		var upgrade_editor: UpgradeEditor = child as UpgradeEditor
+		if upgrade_editor:
+			upgrade_editor.set_process(visible)
 
 
 func _get_plugin_name():
@@ -314,7 +318,6 @@ func change_tree(object: Variant) -> void:
 	#FIXME: Need to handle this better when we have non-minigame trees
 	if object is MinigameData:
 		current_data = object
-		_draw_upgrade_tree(current_data)
 		_make_visible(true)
 	elif not object is BaseUpgrade:
 		current_data = null

--- a/src/addons/upgrade_tree/upgrade_tree_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.gd
@@ -152,12 +152,11 @@ func _enter_tree() -> void:
 	graph_edit.disconnection_request.connect(_on_disconnection_request)
 
 	file_dialog = FileDialog.new()
-	file_dialog.access = FileDialog.ACCESS_FILESYSTEM
-	file_dialog.file_mode = FileDialog.FILE_MODE_SAVE_FILE
 	file_dialog.access = FileDialog.ACCESS_RESOURCES
-	file_dialog.filters = PackedStringArray(["*.res", "*.tres", "*.*"])
+	file_dialog.file_mode = FileDialog.FILE_MODE_SAVE_FILE
+		file_dialog.filters = PackedStringArray(["*.tres"])
 	file_dialog.file_selected.connect(_on_file_selected)
-	file_dialog.name = "SaveResource"
+	file_dialog.name = "Save Upgrade"
 	upgrade_tree_editor_instance.add_child(file_dialog)
 
 

--- a/src/addons/upgrade_tree/upgrade_tree_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.gd
@@ -321,10 +321,29 @@ func _on_disconnection_request(from_node, from_port, to_node, to_port):
 
 
 func _on_connection_request(from_node, from_port, to_node, to_port):
+var from_node_instance: UpgradeEditor = graph_edit.get_node_or_null(NodePath(from_node))
+	var to_node_instance: UpgradeEditor = graph_edit.get_node_or_null(NodePath(to_node))
+
 	# Don't connect to input that is already connected
+if !from_node_instance is UpgradeEditor:
+		push_error("refusing to connect from an invalid node: ", from_node)
+		return
+
+	if !to_node_instance is UpgradeEditor:
+		push_error("refusing to connect from %s to an invalid node: %s" % [from_node, to_node])
+		return
+
+	if !from_node_instance.upgrade.resource_path:
+		push_error("refusing to connect from an unsaved upgrade: ", from_node_instance.upgrade.name)
+		return
+
+	if !to_node_instance.upgrade.resource_path:
+		push_error("refusing to connect to an unsaved upgrade: ", to_node_instance.upgrade.name)
+		return
+
 	for con in graph_edit.get_connection_list():
 		if con.to_node == to_node and con.to_port == to_port:
-print("refusing to connect %s with %s, via port %s" % [from_node.upgrade.name, to_node.upgrade.name, to_port])
+push_warning("refusing to connect %s with %s, via port %s" % [from_node_instance.upgrade.name, to_node_instance.upgrade.name, to_port])
 			return
 	var from_node_instance: UpgradeEditor = graph_edit.get_node_or_null(NodePath(from_node))
 	var to_node_instance: UpgradeEditor = graph_edit.get_node_or_null(NodePath(to_node))

--- a/src/addons/upgrade_tree/upgrade_tree_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.gd
@@ -266,6 +266,7 @@ func _on_delete_upgrade_pressed() -> void:
 func _on_reload_resources_pressed() -> void:
 	_draw_upgrade_tree(current_data)
 
+
 func _upgrade_has_unlockable(p_root: BaseUpgrade, p_unlockable: BaseUpgrade) -> bool:
 	for unlockable in p_root.unlocks:
 		# let's hope no one made an infinite loop kk?

--- a/src/addons/upgrade_tree/upgrade_tree_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.gd
@@ -372,9 +372,7 @@ if !from_node_instance is UpgradeEditor:
 		if con.to_node == to_node and con.to_port == to_port:
 push_warning("refusing to connect %s with %s, via port %s" % [from_node_instance.upgrade.name, to_node_instance.upgrade.name, to_port])
 			return
-	var from_node_instance: UpgradeEditor = graph_edit.get_node_or_null(NodePath(from_node))
-	var to_node_instance: UpgradeEditor = graph_edit.get_node_or_null(NodePath(to_node))
-
+	
 	from_node_instance.upgrade.unlocks.append(to_node_instance.upgrade)
 
 	# the to_node upgrade would no longer be a root node, so remove it if it was

--- a/src/addons/upgrade_tree/upgrade_tree_editor.tscn
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.tscn
@@ -48,7 +48,7 @@ offset_top = 11.0
 offset_right = 1151.0
 offset_bottom = 65.0
 theme_override_font_sizes/font_size = 18
-text = "Reload resources"
+text = "Reload Tree"
 
 [node name="UpgradeTreeDropdown" type="OptionButton" parent="."]
 layout_mode = 0

--- a/src/modules/minigame/common/minigame_data.gd
+++ b/src/modules/minigame/common/minigame_data.gd
@@ -20,12 +20,14 @@ extends Resource
 
 
 ## Returns all upgrades in the tree via recursion
-func get_all_upgrades(branch: BaseUpgrade = null, unlocked_only: bool = false) -> Array[Resource]:
-	var result: Array[Resource]
-	var root_nodes: Array[Resource]
+func get_all_upgrades(
+	branch: BaseUpgrade = null, unlocked_only: bool = false
+) -> Array[BaseUpgrade]:
+	var result: Array[BaseUpgrade]
+	var root_nodes: Array[BaseUpgrade]
 
 	if branch:
-		root_nodes = branch.unlocks
+		root_nodes.assign(branch.unlocks)
 	else:
 		# Array type conversion BaseUpgrade <- upgrade_tree_root_nodes
 		root_nodes.assign(upgrade_tree_root_nodes)


### PR DESCRIPTION
- Fixes minigame data not being able to have unlocks assigned
- Editor now refreshes the tree automatically
- Editor prevent you from doing something silly, like connecting upgrades before they've been saved to disk
- Editor modifies minigame data to add/remove root upgrades, as upgrades are added, connected, disconnected, and saved, as well as when the tree is loaded (to prevent weird issues with manually assigning upgrades)