### PR TITLE
Upgrade editor tree improvements

### DIFF
--- a/src/addons/upgrade_tree/upgrade_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_editor.gd
@@ -28,6 +28,8 @@ func set_fields_from_upgrade() -> void:
 
 	if !upgrade.resource_path:
 		add_info_error("NOT SAVED TO FILE")
+	else:
+		add_info("[i]%s[/i]" % upgrade.resource_path.get_file())
 
 	if !upgrade.logic:
 		add_info_error("MISSING LOGIC")
@@ -65,4 +67,4 @@ func add_info(msg: String) -> void:
 	if info.text != "":
 		info.append_text("\n")
 
-	info.append_text("%s\n" %msg)
+	info.append_text("%s\n" % msg)

--- a/src/addons/upgrade_tree/upgrade_editor.tscn
+++ b/src/addons/upgrade_tree/upgrade_editor.tscn
@@ -38,6 +38,7 @@ scale = Vector2(0.5, 0.5)
 
 [node name="Information" type="RichTextLabel" parent="."]
 unique_name_in_owner = true
+custom_minimum_size = Vector2(600, 500)
 layout_mode = 2
 theme = ExtResource("1_n60oh")
 bbcode_enabled = true

--- a/src/addons/upgrade_tree/upgrade_tree_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.gd
@@ -260,7 +260,7 @@ func _on_add_upgrade_pressed() -> void:
 
 			var upgrade_editor_node := current_selected_node as UpgradeEditor
 			if upgrade_editor_node:
-				upgrade.logic = upgrade_editor_node.upgrade.logic
+				upgrade.logic = upgrade_editor_node.upgrade.logic.duplicate(false)
 				upgrade.max_level = upgrade_editor_node.upgrade.max_level
 
 		# explicitly passing null because it auto-connects and that's kinda frustrating tbh

--- a/src/addons/upgrade_tree/upgrade_tree_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.gd
@@ -274,6 +274,17 @@ func _on_save_upgrade_pressed() -> void:
 	file_dialog.popup_centered()
 
 
+func _try_add_root(p_upgrade: BaseUpgrade) -> bool:
+	if !current_data:
+		return false
+
+	if _upgrade_is_unlockable(p_upgrade) || current_data.upgrade_tree_root_nodes.has(p_upgrade):
+		return false
+
+	current_data.upgrade_tree_root_nodes.append(p_upgrade)
+	return true
+
+
 func _on_delete_upgrade_pressed() -> void:
 	for child in graph_edit.get_children():
 		if child is UpgradeEditor:

--- a/src/addons/upgrade_tree/upgrade_tree_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.gd
@@ -204,9 +204,21 @@ func _draw_upgrade_tree(data: MinigameData) -> void:
 	# remove any root upgrades which actually aren't root upgrades, because something unlocks them
 	data.upgrade_tree_root_nodes = data.upgrade_tree_root_nodes.filter(
 		func(upgrade: BaseUpgrade):
-		var unlockable := _upgrade_is_unlockable(upgrade)
-		return !unlockable
+			var unlockable := _upgrade_is_unlockable(upgrade)
+			return !unlockable
 	)
+
+	# remove any duplicate root upgrades
+	var upgrades_found: Array[BaseUpgrade]
+	data.upgrade_tree_root_nodes = data.upgrade_tree_root_nodes.filter(
+		func(upgrade: BaseUpgrade):
+			if !upgrades_found.has(upgrade):
+				upgrades_found.append(upgrade)
+				return true
+
+			return false
+	)
+	upgrades_found.clear()
 
 	for upgrade in data.upgrade_tree_root_nodes:
 		if not upgrade:

--- a/src/addons/upgrade_tree/upgrade_tree_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.gd
@@ -293,8 +293,12 @@ func _on_delete_upgrade_pressed() -> void:
 				_save_upgrade(child.upgrade)
 				graph_edit.disconnect_node(child.name, 0, current_selected_node.name, 0)
 			if child.upgrade in current_selected_node.upgrade.unlocks:
-				child.upgrade.unlocks.erase(current_selected_node.upgrade)
+				_try_add_root(child.upgrade) #todo: we could force them to connect instead?
 				graph_edit.disconnect_node(current_selected_node.name, 0, child.name, 0)
+
+	# remove it as a root if it was one. if not, then nothing happens
+	current_data.upgrade_tree_root_nodes.erase(current_selected_node.upgrade)
+
 	graph_edit.remove_child(current_selected_node)
 	current_selected_node = null
 

--- a/src/addons/upgrade_tree/upgrade_tree_editor.gd
+++ b/src/addons/upgrade_tree/upgrade_tree_editor.gd
@@ -353,7 +353,6 @@ func _on_disconnection_request(from_node, from_port, to_node, to_port):
 	if current_data:
 		var idx := current_data.upgrade_tree_root_nodes.find(to_node_instance.upgrade)
 		if idx < 0:
-			print("disconnected, adding as root: ", to_node_instance.upgrade.name)
 			current_data.upgrade_tree_root_nodes.append(to_node_instance.upgrade)
 
 	_save_upgrade(from_node_instance.upgrade)
@@ -393,7 +392,6 @@ func _on_connection_request(from_node, from_port, to_node, to_port):
 	if current_data:
 		var idx := current_data.upgrade_tree_root_nodes.find(to_node_instance.upgrade)
 		if idx >= 0:
-			print("found as root, removing: ", to_node_instance.upgrade.name)
 			current_data.upgrade_tree_root_nodes.remove_at(idx)
 
 	# todo: handle removing any other unlock?

--- a/src/modules/minigame/earth_potato_herding/eph_upgrades/nutritious_potato_upgrade.tres
+++ b/src/modules/minigame/earth_potato_herding/eph_upgrades/nutritious_potato_upgrade.tres
@@ -110,4 +110,4 @@ unlocks = Array[Resource]([])
 description_prefix = "Increase potato yield by"
 description_suffix = ""
 description_modifier_format = 1
-metadata/tree_editor_version_saved = 1
+metadata/_tree_editor_version_saved = 1

--- a/src/modules/minigame/earth_potato_herding/eph_upgrades/spirit_keeper_brightness.tres
+++ b/src/modules/minigame/earth_potato_herding/eph_upgrades/spirit_keeper_brightness.tres
@@ -110,4 +110,4 @@ unlocks = Array[Resource]([])
 description_prefix = "Increase ligh around spirit keeper by"
 description_suffix = ""
 description_modifier_format = 0
-metadata/tree_editor_version_saved = 1
+metadata/_tree_editor_version_saved = 1

--- a/src/modules/minigame/earth_potato_herding/eph_upgrades/spirit_keeper_speed.tres
+++ b/src/modules/minigame/earth_potato_herding/eph_upgrades/spirit_keeper_speed.tres
@@ -110,4 +110,4 @@ unlocks = Array[Resource]([])
 description_prefix = "Increase Spirit Keeper speed by"
 description_suffix = ""
 description_modifier_format = 0
-metadata/tree_editor_version_saved = 1
+metadata/_tree_editor_version_saved = 1


### PR DESCRIPTION
- Fixed the nodes getting weirdly long sometimes due to the warnings/errors
- Show the saved filename for each upgrade
- Remove duplicate root nodes
- Handle deleting a node correctly
- Fix upgrade nodes being given the same reference to an upgrade logic resource
- Moved metadata to use underscores, which hides it in the editor
- Newly saved nodes are now correctly added as root, if they aren't unlocked by something else