### PR TITLE
Help menu keybind fill

### DIFF
--- a/src/modules/menu/minigame_help.gd
+++ b/src/modules/menu/minigame_help.gd
@@ -18,8 +18,13 @@ func setup(p_minigame: BaseMinigame) -> void:
 	minigame = p_minigame
 	minigame.playing.connect(
 		func():
+			var binds: Dictionary[String, String] = {}
+			for k in GameSettings.keybinds:
+				if (GameSettings.keybinds[k] as Array).is_empty():
+					continue
+				binds[k] = OS.get_keycode_string(GameSettings.keybinds[k][0])
 			help_text.text = ""
-			help_text.append_text(minigame.data.how_to_play)
+			help_text.append_text(minigame.data.how_to_play.format(binds))
 	)
 
 

--- a/src/modules/minigame/water_rowing_rapids/data/water_rowing_rapids_data.tres
+++ b/src/modules/minigame/water_rowing_rapids/data/water_rowing_rapids_data.tres
@@ -12,7 +12,7 @@
 script = ExtResource("2_nvcen")
 display_name = "Rowing Rapids"
 how_to_play = "Move down the river and collect lost spirits!
-Use primary action to boost when the marker is within the green area. If you miss, you'll take damage!
+Press {primary_action} to boost when the marker is within the green area. If you miss, you'll take damage!
 Collecting spirits will grant you points."
 music_track = "rowing_rapids"
 minigame_scene = ExtResource("1_echju")


### PR DESCRIPTION
Adds keybind filling into minigame help menu
## Reasons why I did this:
- It was easy
- Player can rebind controls, so it's kind of nessicary