### PR TITLE
Introduce savegame versions

### DIFF
--- a/src/modules/save_system/save_game_manager.gd
+++ b/src/modules/save_system/save_game_manager.gd
@@ -1,6 +1,7 @@
 extends Node
 
 const SAVE_PATH = "user://savegame.tres"
+const SAVE_GAME_VERSION = 1
 
 var world_state: WorldState
 
@@ -14,7 +15,15 @@ func start_game():
 		)
 		save()
 	else:
-		world_state = load(SAVE_PATH)
+		var tmp_world_state: WorldState = load(SAVE_PATH)
+		if tmp_world_state.save_game_version < SAVE_GAME_VERSION:
+			push_warning("Detected old save game version. Deleting file!")
+			tmp_world_state = null
+			reset()
+			return
+
+		world_state = tmp_world_state
+
 	EventBus.game_loaded.emit(world_state)
 
 
@@ -27,5 +36,6 @@ func reset():
 
 
 func save():
+	world_state.save_game_version = SAVE_GAME_VERSION
 	var error: Error = ResourceSaver.save(world_state)
 	assert(error == OK)

--- a/src/modules/save_system/world_state.gd
+++ b/src/modules/save_system/world_state.gd
@@ -1,6 +1,8 @@
 class_name WorldState
 extends Resource
 
+@export_storage var save_game_version: int = 0
+
 # Dictionary mapping upgrade UIDs to their unlock levels
 @export var minigame_unlock_levels: Dictionary[StringName, int]
 


### PR DESCRIPTION
If new save game fields are introduced in the World/PlayerState you can now increase the number in `SaveGameManager.VERSION` by one, which will delete older savefiles when they are loaded.