### PR TITLE
Lower VRAM from main menu animation

### DIFF
--- a/src/assets/ui/background_frames/000.png.import
+++ b/src/assets/ui/background_frames/000.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://kv7xoyh4l0cp"
-path="res://.godot/imported/000.png-c7be97bcb7498a4cc3af23fb2521396e.ctex"
+path.s3tc="res://.godot/imported/000.png-c7be97bcb7498a4cc3af23fb2521396e.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/000.png"
-dest_files=["res://.godot/imported/000.png-c7be97bcb7498a4cc3af23fb2521396e.ctex"]
+dest_files=["res://.godot/imported/000.png-c7be97bcb7498a4cc3af23fb2521396e.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/001.png.import
+++ b/src/assets/ui/background_frames/001.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bjcp6omel0vm6"
-path="res://.godot/imported/001.png-59e493355bc463c0302c77397fd02b3a.ctex"
+path.s3tc="res://.godot/imported/001.png-59e493355bc463c0302c77397fd02b3a.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/001.png"
-dest_files=["res://.godot/imported/001.png-59e493355bc463c0302c77397fd02b3a.ctex"]
+dest_files=["res://.godot/imported/001.png-59e493355bc463c0302c77397fd02b3a.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/002.png.import
+++ b/src/assets/ui/background_frames/002.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://b266s3dvkiwyx"
-path="res://.godot/imported/002.png-97798689bde05fe34c799b89db567d85.ctex"
+path.s3tc="res://.godot/imported/002.png-97798689bde05fe34c799b89db567d85.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/002.png"
-dest_files=["res://.godot/imported/002.png-97798689bde05fe34c799b89db567d85.ctex"]
+dest_files=["res://.godot/imported/002.png-97798689bde05fe34c799b89db567d85.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/003.png.import
+++ b/src/assets/ui/background_frames/003.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cnwo5h07rb5kn"
-path="res://.godot/imported/003.png-87b5aaba42687650480381e72c717e0b.ctex"
+path.s3tc="res://.godot/imported/003.png-87b5aaba42687650480381e72c717e0b.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/003.png"
-dest_files=["res://.godot/imported/003.png-87b5aaba42687650480381e72c717e0b.ctex"]
+dest_files=["res://.godot/imported/003.png-87b5aaba42687650480381e72c717e0b.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/004.png.import
+++ b/src/assets/ui/background_frames/004.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://by1ruwtj5hx2b"
-path="res://.godot/imported/004.png-690ebe70bf80929659ef3e81dd9a816e.ctex"
+path.s3tc="res://.godot/imported/004.png-690ebe70bf80929659ef3e81dd9a816e.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/004.png"
-dest_files=["res://.godot/imported/004.png-690ebe70bf80929659ef3e81dd9a816e.ctex"]
+dest_files=["res://.godot/imported/004.png-690ebe70bf80929659ef3e81dd9a816e.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/005.png.import
+++ b/src/assets/ui/background_frames/005.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cbw16ohxqody1"
-path="res://.godot/imported/005.png-c2cb0f3cd2af5bf163e74f167b2c8934.ctex"
+path.s3tc="res://.godot/imported/005.png-c2cb0f3cd2af5bf163e74f167b2c8934.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/005.png"
-dest_files=["res://.godot/imported/005.png-c2cb0f3cd2af5bf163e74f167b2c8934.ctex"]
+dest_files=["res://.godot/imported/005.png-c2cb0f3cd2af5bf163e74f167b2c8934.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/006.png.import
+++ b/src/assets/ui/background_frames/006.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://lw7b03gvxpsp"
-path="res://.godot/imported/006.png-9c75789444d305c3e3c15699e52c9add.ctex"
+path.s3tc="res://.godot/imported/006.png-9c75789444d305c3e3c15699e52c9add.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/006.png"
-dest_files=["res://.godot/imported/006.png-9c75789444d305c3e3c15699e52c9add.ctex"]
+dest_files=["res://.godot/imported/006.png-9c75789444d305c3e3c15699e52c9add.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/007.png.import
+++ b/src/assets/ui/background_frames/007.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://c0kaiaxpu0iws"
-path="res://.godot/imported/007.png-40271ea7c491787e99bc53348d4af8bc.ctex"
+path.s3tc="res://.godot/imported/007.png-40271ea7c491787e99bc53348d4af8bc.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/007.png"
-dest_files=["res://.godot/imported/007.png-40271ea7c491787e99bc53348d4af8bc.ctex"]
+dest_files=["res://.godot/imported/007.png-40271ea7c491787e99bc53348d4af8bc.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/008.png.import
+++ b/src/assets/ui/background_frames/008.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://6kti7ixfin1d"
-path="res://.godot/imported/008.png-23935b1f937fe5d343f64c0f929e54e5.ctex"
+path.s3tc="res://.godot/imported/008.png-23935b1f937fe5d343f64c0f929e54e5.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/008.png"
-dest_files=["res://.godot/imported/008.png-23935b1f937fe5d343f64c0f929e54e5.ctex"]
+dest_files=["res://.godot/imported/008.png-23935b1f937fe5d343f64c0f929e54e5.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/009.png.import
+++ b/src/assets/ui/background_frames/009.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://moq6dfco61rx"
-path="res://.godot/imported/009.png-499f71c14c5598be3c1741d5d0222157.ctex"
+path.s3tc="res://.godot/imported/009.png-499f71c14c5598be3c1741d5d0222157.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/009.png"
-dest_files=["res://.godot/imported/009.png-499f71c14c5598be3c1741d5d0222157.ctex"]
+dest_files=["res://.godot/imported/009.png-499f71c14c5598be3c1741d5d0222157.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/010.png.import
+++ b/src/assets/ui/background_frames/010.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://bwhj307kr2by5"
-path="res://.godot/imported/010.png-ed4e329cc8790faed1e352bb4e2663a4.ctex"
+path.s3tc="res://.godot/imported/010.png-ed4e329cc8790faed1e352bb4e2663a4.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/010.png"
-dest_files=["res://.godot/imported/010.png-ed4e329cc8790faed1e352bb4e2663a4.ctex"]
+dest_files=["res://.godot/imported/010.png-ed4e329cc8790faed1e352bb4e2663a4.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/011.png.import
+++ b/src/assets/ui/background_frames/011.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://c8qgmiletchm8"
-path="res://.godot/imported/011.png-5d6504a4373f1c05ff8ce6266e2edf3c.ctex"
+path.s3tc="res://.godot/imported/011.png-5d6504a4373f1c05ff8ce6266e2edf3c.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/011.png"
-dest_files=["res://.godot/imported/011.png-5d6504a4373f1c05ff8ce6266e2edf3c.ctex"]
+dest_files=["res://.godot/imported/011.png-5d6504a4373f1c05ff8ce6266e2edf3c.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/012.png.import
+++ b/src/assets/ui/background_frames/012.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://b7yyfekyrdecw"
-path="res://.godot/imported/012.png-530d3723c386433e5bcb6701160ac598.ctex"
+path.s3tc="res://.godot/imported/012.png-530d3723c386433e5bcb6701160ac598.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/012.png"
-dest_files=["res://.godot/imported/012.png-530d3723c386433e5bcb6701160ac598.ctex"]
+dest_files=["res://.godot/imported/012.png-530d3723c386433e5bcb6701160ac598.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/013.png.import
+++ b/src/assets/ui/background_frames/013.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://dgwtus7x6w4eh"
-path="res://.godot/imported/013.png-aef97ebfa0feeedf2e77045f7c1a00a8.ctex"
+path.s3tc="res://.godot/imported/013.png-aef97ebfa0feeedf2e77045f7c1a00a8.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/013.png"
-dest_files=["res://.godot/imported/013.png-aef97ebfa0feeedf2e77045f7c1a00a8.ctex"]
+dest_files=["res://.godot/imported/013.png-aef97ebfa0feeedf2e77045f7c1a00a8.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/014.png.import
+++ b/src/assets/ui/background_frames/014.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cs4usd5f1vrh8"
-path="res://.godot/imported/014.png-803ad8b6b88f528f8f92b36c86c1f534.ctex"
+path.s3tc="res://.godot/imported/014.png-803ad8b6b88f528f8f92b36c86c1f534.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/014.png"
-dest_files=["res://.godot/imported/014.png-803ad8b6b88f528f8f92b36c86c1f534.ctex"]
+dest_files=["res://.godot/imported/014.png-803ad8b6b88f528f8f92b36c86c1f534.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/015.png.import
+++ b/src/assets/ui/background_frames/015.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cmncq4tqvp4yt"
-path="res://.godot/imported/015.png-bb522927cfd6068f453cd8c604ce5e80.ctex"
+path.s3tc="res://.godot/imported/015.png-bb522927cfd6068f453cd8c604ce5e80.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/015.png"
-dest_files=["res://.godot/imported/015.png-bb522927cfd6068f453cd8c604ce5e80.ctex"]
+dest_files=["res://.godot/imported/015.png-bb522927cfd6068f453cd8c604ce5e80.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/016.png.import
+++ b/src/assets/ui/background_frames/016.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://c0jijnuai44fs"
-path="res://.godot/imported/016.png-71dc81438a584ac719e3c8fb39e97fad.ctex"
+path.s3tc="res://.godot/imported/016.png-71dc81438a584ac719e3c8fb39e97fad.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/016.png"
-dest_files=["res://.godot/imported/016.png-71dc81438a584ac719e3c8fb39e97fad.ctex"]
+dest_files=["res://.godot/imported/016.png-71dc81438a584ac719e3c8fb39e97fad.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/017.png.import
+++ b/src/assets/ui/background_frames/017.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://d2bxamesyf1dn"
-path="res://.godot/imported/017.png-a551a44ee2004cd671455fccc5e322db.ctex"
+path.s3tc="res://.godot/imported/017.png-a551a44ee2004cd671455fccc5e322db.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/017.png"
-dest_files=["res://.godot/imported/017.png-a551a44ee2004cd671455fccc5e322db.ctex"]
+dest_files=["res://.godot/imported/017.png-a551a44ee2004cd671455fccc5e322db.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/018.png.import
+++ b/src/assets/ui/background_frames/018.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://b5nlappkp7jnd"
-path="res://.godot/imported/018.png-0baa08dd044eb09d0f534bbb7861162c.ctex"
+path.s3tc="res://.godot/imported/018.png-0baa08dd044eb09d0f534bbb7861162c.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/018.png"
-dest_files=["res://.godot/imported/018.png-0baa08dd044eb09d0f534bbb7861162c.ctex"]
+dest_files=["res://.godot/imported/018.png-0baa08dd044eb09d0f534bbb7861162c.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/019.png.import
+++ b/src/assets/ui/background_frames/019.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://drj74n5h4wxi8"
-path="res://.godot/imported/019.png-b6324fb2326e672b77394bd05f5a8b79.ctex"
+path.s3tc="res://.godot/imported/019.png-b6324fb2326e672b77394bd05f5a8b79.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/019.png"
-dest_files=["res://.godot/imported/019.png-b6324fb2326e672b77394bd05f5a8b79.ctex"]
+dest_files=["res://.godot/imported/019.png-b6324fb2326e672b77394bd05f5a8b79.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/020.png.import
+++ b/src/assets/ui/background_frames/020.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://b01rjj4ghnn77"
-path="res://.godot/imported/020.png-463b51d498f3c321158cfc0732542cb5.ctex"
+path.s3tc="res://.godot/imported/020.png-463b51d498f3c321158cfc0732542cb5.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/020.png"
-dest_files=["res://.godot/imported/020.png-463b51d498f3c321158cfc0732542cb5.ctex"]
+dest_files=["res://.godot/imported/020.png-463b51d498f3c321158cfc0732542cb5.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/021.png.import
+++ b/src/assets/ui/background_frames/021.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://c6wkgnfv3gwjp"
-path="res://.godot/imported/021.png-0bd4c51f615e370e3cc7013978ebfe3d.ctex"
+path.s3tc="res://.godot/imported/021.png-0bd4c51f615e370e3cc7013978ebfe3d.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/021.png"
-dest_files=["res://.godot/imported/021.png-0bd4c51f615e370e3cc7013978ebfe3d.ctex"]
+dest_files=["res://.godot/imported/021.png-0bd4c51f615e370e3cc7013978ebfe3d.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/022.png.import
+++ b/src/assets/ui/background_frames/022.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://dl0kxfpik6u4m"
-path="res://.godot/imported/022.png-79e8c5c35373b5b3632d3e5269f33fac.ctex"
+path.s3tc="res://.godot/imported/022.png-79e8c5c35373b5b3632d3e5269f33fac.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/022.png"
-dest_files=["res://.godot/imported/022.png-79e8c5c35373b5b3632d3e5269f33fac.ctex"]
+dest_files=["res://.godot/imported/022.png-79e8c5c35373b5b3632d3e5269f33fac.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/023.png.import
+++ b/src/assets/ui/background_frames/023.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://ci64rgn7umonw"
-path="res://.godot/imported/023.png-d10a2d74e15eeb6c29e5d3a0d61883fa.ctex"
+path.s3tc="res://.godot/imported/023.png-d10a2d74e15eeb6c29e5d3a0d61883fa.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/023.png"
-dest_files=["res://.godot/imported/023.png-d10a2d74e15eeb6c29e5d3a0d61883fa.ctex"]
+dest_files=["res://.godot/imported/023.png-d10a2d74e15eeb6c29e5d3a0d61883fa.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/024.png.import
+++ b/src/assets/ui/background_frames/024.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://rhuan4bvpqri"
-path="res://.godot/imported/024.png-cf1e284da67f7f71eacf30d147f89c46.ctex"
+path.s3tc="res://.godot/imported/024.png-cf1e284da67f7f71eacf30d147f89c46.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/024.png"
-dest_files=["res://.godot/imported/024.png-cf1e284da67f7f71eacf30d147f89c46.ctex"]
+dest_files=["res://.godot/imported/024.png-cf1e284da67f7f71eacf30d147f89c46.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/025.png.import
+++ b/src/assets/ui/background_frames/025.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://c8hvatskh0hss"
-path="res://.godot/imported/025.png-06ed01bbe9a6b0ea2ead4b31796a58e0.ctex"
+path.s3tc="res://.godot/imported/025.png-06ed01bbe9a6b0ea2ead4b31796a58e0.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/025.png"
-dest_files=["res://.godot/imported/025.png-06ed01bbe9a6b0ea2ead4b31796a58e0.ctex"]
+dest_files=["res://.godot/imported/025.png-06ed01bbe9a6b0ea2ead4b31796a58e0.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/026.png.import
+++ b/src/assets/ui/background_frames/026.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cej1xtnjc47a5"
-path="res://.godot/imported/026.png-06f57a9e65a24d9a071e70482e335810.ctex"
+path.s3tc="res://.godot/imported/026.png-06f57a9e65a24d9a071e70482e335810.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/026.png"
-dest_files=["res://.godot/imported/026.png-06f57a9e65a24d9a071e70482e335810.ctex"]
+dest_files=["res://.godot/imported/026.png-06f57a9e65a24d9a071e70482e335810.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/027.png.import
+++ b/src/assets/ui/background_frames/027.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://clg3cv3w3l6uc"
-path="res://.godot/imported/027.png-89288a873234480293e8fea44dc4ba86.ctex"
+path.s3tc="res://.godot/imported/027.png-89288a873234480293e8fea44dc4ba86.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/027.png"
-dest_files=["res://.godot/imported/027.png-89288a873234480293e8fea44dc4ba86.ctex"]
+dest_files=["res://.godot/imported/027.png-89288a873234480293e8fea44dc4ba86.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/028.png.import
+++ b/src/assets/ui/background_frames/028.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://cm1y8vuom05l6"
-path="res://.godot/imported/028.png-e09f752796b72686bc907ae45d4b0218.ctex"
+path.s3tc="res://.godot/imported/028.png-e09f752796b72686bc907ae45d4b0218.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/028.png"
-dest_files=["res://.godot/imported/028.png-e09f752796b72686bc907ae45d4b0218.ctex"]
+dest_files=["res://.godot/imported/028.png-e09f752796b72686bc907ae45d4b0218.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1

--- a/src/assets/ui/background_frames/029.png.import
+++ b/src/assets/ui/background_frames/029.png.import
@@ -3,19 +3,20 @@
 importer="texture"
 type="CompressedTexture2D"
 uid="uid://ceil4nllfskfj"
-path="res://.godot/imported/029.png-ed179ac411cdfdd3fa65882502dac5ec.ctex"
+path.s3tc="res://.godot/imported/029.png-ed179ac411cdfdd3fa65882502dac5ec.s3tc.ctex"
 metadata={
-"vram_texture": false
+"imported_formats": ["s3tc_bptc"],
+"vram_texture": true
 }
 
 [deps]
 
 source_file="res://assets/ui/background_frames/029.png"
-dest_files=["res://.godot/imported/029.png-ed179ac411cdfdd3fa65882502dac5ec.ctex"]
+dest_files=["res://.godot/imported/029.png-ed179ac411cdfdd3fa65882502dac5ec.s3tc.ctex"]
 
 [params]
 
-compress/mode=0
+compress/mode=2
 compress/high_quality=false
 compress/lossy_quality=0.7
 compress/hdr_compression=1


### PR DESCRIPTION
@klipnity experimented with this and found the lower quality wasn't noticeable. They used WebP's but the additional pre-import compression increased the post-import disk size and VRAM usage compared to PNG, so I've kept them as PNG