### PR TITLE
Validate no changed files on CI after running builds or tests

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,10 +43,9 @@ jobs:
           archive_output: true
           export_debug: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
-      - name: Git Diff Post-Build
+      - name: Validate Git Diff
         run: |
-          git status
-          git diff
+          ./scripts/validate_git_diff.sh
 
       - name: show build directory
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -57,7 +57,6 @@ jobs:
           gut_params: -gdir=res://tests/unit
           project_path: src
 
-      - name: Git Diff Post-Test
+      - name: Validate Git Diff
         run: |
-          git status
-          git diff
+          ./scripts/validate_git_diff.sh

--- a/scripts/validate_git_diff.sh
+++ b/scripts/validate_git_diff.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Get list of modified/staged/deleted files, ignoring untracsked (??) and ignored (!!)
+modified_files=$(git status --porcelain | grep -Ev '^\?\? |^!! ' || true)
+
+echo "#####################"
+echo "       RESULTS       "
+echo "#####################"
+if [[ -n "$modified_files" ]]; then
+    echo "CI FAILED DUE TO THESE MODIFIED FILES:"
+    echo "$modified_files"
+    echo ""
+    echo ""
+    echo ""
+    echo ""
+    echo ""
+    echo "THE GIT DIFF:"
+    echo "$(git diff || true)"
+    echo ""
+    echo ""
+    echo ""
+    echo ""
+    echo ""
+    exit 1
+else
+    echo "ALL GOOD :) :) :)"
+    echo ""
+    echo ""
+    echo ""
+    echo ""
+    echo ""
+    exit 0
+fi


### PR DESCRIPTION
Sometimes godot will modify files after importing, building, or testing, which usually indicates either a problem, or a difference that will get regenerated on our local machines when we open the projects ourselves, so this would cause the CI jobs to fail instead